### PR TITLE
Close #7 Select Folder will open directory of parent directory if any

### DIFF
--- a/app.go
+++ b/app.go
@@ -44,6 +44,25 @@ func (a *App) GetDirectory() string {
 	return directory
 }
 
+// Open a Dialog for user to select Directory, this dialog will show default directory when open.
+//
+// If Error is occur, then this function will return an empty string
+func (a *App) GetDirectoryWithDefault(defaultDirectory string) string {
+	// Try to get parent of default directory
+	dir := filepath.Dir(defaultDirectory)
+
+	directory, err := runtime.OpenDirectoryDialog(a.ctx, runtime.OpenDialogOptions{
+		Title:            "Select Directory",
+		DefaultDirectory: dir,
+	})
+
+	if err != nil {
+		logrus.Warnf("Error when getting directory from user: %v\n", err)
+		return ""
+	}
+	return directory
+}
+
 // Perform Quick Export Action,
 // where ComicInfo.xml file can not be modified before archived.
 //

--- a/frontend/src/pages/folderSelect.tsx
+++ b/frontend/src/pages/folderSelect.tsx
@@ -10,7 +10,11 @@ import Collapse from "react-bootstrap/Collapse";
 import { CompleteModal, ErrorModal, LoadingModal } from "../modal";
 
 // Wails
-import { GetDirectory, QuickExportKomga } from "../../wailsjs/go/main/App";
+import {
+	GetDirectory,
+	QuickExportKomga,
+	GetDirectoryWithDefault,
+} from "../../wailsjs/go/main/App";
 
 /** Button Props Interface for FolderSelect */
 type ButtonProps = {
@@ -67,9 +71,15 @@ export default function FolderSelect({ handleConfirm }: ButtonProps) {
 	const [errMsg, setErrMsg] = useState("");
 
 	function handleSelect() {
-		GetDirectory().then((input) => {
-			setDirectory(input);
-		});
+		if (directory != "") {
+			GetDirectoryWithDefault(directory).then((input) => {
+				setDirectory(input);
+			});
+		} else {
+			GetDirectory().then((input) => {
+				setDirectory(input);
+			});
+		}
 	}
 
 	function handleQuickExport() {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -3,4 +3,6 @@
 
 export function GetDirectory():Promise<string>;
 
+export function GetDirectoryWithDefault(arg1:string):Promise<string>;
+
 export function QuickExportKomga(arg1:string):Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -6,6 +6,10 @@ export function GetDirectory() {
   return window['go']['main']['App']['GetDirectory']();
 }
 
+export function GetDirectoryWithDefault(arg1) {
+  return window['go']['main']['App']['GetDirectoryWithDefault'](arg1);
+}
+
 export function QuickExportKomga(arg1) {
   return window['go']['main']['App']['QuickExportKomga'](arg1);
 }


### PR DESCRIPTION
### Changes Made

- When select folder, if there was any path in textfield, the file dialog will show the parent directory of the path when opened

### Reason of Changes

Fix #7
### Checklist:

- [x] I have run the new code and ensure the change is work expected
- [x] I have write/modify comments to important function & hard-to-understand code
- [x] I have create/modify corresponding test for new changes
- [x] I have made corresponding changes to the documentation
- [x] I have run all new & existing test and pass locally with my changes
- [x] I have checked my code has no misspellings & no warnings
- [x] I have checked that only essential code remains in this pull request
