### PR TITLE
Read `ComicInfo.xml` to GUI if file exist

### DIFF
--- a/.vscode/.cspell/package-dictionary.txt
+++ b/.vscode/.cspell/package-dictionary.txt
@@ -1,7 +1,14 @@
 # Dictionary for imported packages
+assetserver
+Colour
+Debugf
 Equalf
+Infof
 innerxml
 Komga
 logrus
+sirupsen
 stretchr
 Valuesf
+wailsapp
+Warnf

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A simple GUI for create `ComicInfo.xml` and `.cbz` archive at easy way.
 
 After select folder for generate `ComicInfo.xml`, a preview page will appear. User can change content before export real `ComicInfo.xml`.
 
+When there has existing `ComicInfo.xml` file in selected folder, GUI will load existing `ComicInfo.xml` data instead of create a new one.
+
 Currently, this project supports fields:
 
 -   `Title`, `Number`, `Summary`, `Year/Month/Day`, `Web`, `GTIN`

--- a/app.go
+++ b/app.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/xml"
 	"fmt"
 	"gui-comicinfo/internal/archive"
 	"gui-comicinfo/internal/comicinfo"
@@ -147,25 +146,10 @@ func (a *App) QuickExportKomga(folder string) string {
 		return err.Error()
 	}
 
-	output, err := xml.MarshalIndent(c, "  ", "    ")
+	// Write ComicInfo.xml
+	err = comicinfo.Save(c, filepath.Join(absPath, "ComicInfo.xml"))
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
-		return err.Error()
-	}
-
-	// Open File for reading
-	f, err := os.Create(filepath.Join(absPath, "ComicInfo.xml"))
-	if err != nil {
-		return err.Error()
-	}
-	defer f.Close()
-
-	// Write XML Content to file
-	f.Write([]byte("<?xml version=\"1.0\"?>\n"))
-	f.Write(output)
-
-	err = f.Sync()
-	if err != nil {
+		fmt.Printf("error when saving: %v\n", err)
 		return err.Error()
 	}
 
@@ -191,25 +175,10 @@ func (a *App) ExportXml(originalDir string, c *comicinfo.ComicInfo) (errorMsg st
 		return "comicinfo is nil value"
 	}
 
-	output, err := xml.MarshalIndent(c, "  ", "    ")
+	// Save ComicInfo.xml
+	err := comicinfo.Save(c, filepath.Join(originalDir, "ComicInfo.xml"))
 	if err != nil {
 		fmt.Printf("error: %v\n", err)
-		return err.Error()
-	}
-
-	// Open File for reading
-	f, err := os.Create(filepath.Join(originalDir, "ComicInfo.xml"))
-	if err != nil {
-		return err.Error()
-	}
-	defer f.Close()
-
-	// Write XML Content to file
-	f.Write([]byte("<?xml version=\"1.0\"?>\n"))
-	f.Write(output)
-
-	err = f.Sync()
-	if err != nil {
 		return err.Error()
 	}
 
@@ -240,25 +209,10 @@ func (a *App) ExportCbz(inputDir string, exportDir string, c *comicinfo.ComicInf
 		return "empty comic info"
 	}
 
-	// Marshal ComicInfo to XML
-	output, err := xml.MarshalIndent(c, "  ", "    ")
+	// Save ComicInfo.xml
+	err := comicinfo.Save(c, filepath.Join(inputDir, "ComicInfo.xml"))
 	if err != nil {
 		fmt.Printf("error: %v\n", err)
-		return err.Error()
-	}
-
-	// Open File for reading
-	f, err := os.Create(filepath.Join(inputDir, "ComicInfo.xml"))
-	if err != nil {
-		return err.Error()
-	}
-	defer f.Close()
-
-	// Write XML Content to file
-	f.Write([]byte("<?xml version=\"1.0\"?>\n"))
-	f.Write(output)
-	err = f.Sync()
-	if err != nil {
 		return err.Error()
 	}
 

--- a/app.go
+++ b/app.go
@@ -175,6 +175,10 @@ func (a *App) ExportXml(originalDir string, c *comicinfo.ComicInfo) (errorMsg st
 		return "comicinfo is nil value"
 	}
 
+	if originalDir == "" {
+		return "empty folder path"
+	}
+
 	// Save ComicInfo.xml
 	err := comicinfo.Save(c, filepath.Join(originalDir, "ComicInfo.xml"))
 	if err != nil {

--- a/app_test.go
+++ b/app_test.go
@@ -153,7 +153,7 @@ func TestQuickExportKomga(t *testing.T) {
 	// Normal Case
 	dirInput = append(dirInput, valid)
 	errOutput = append(errOutput, "")
-	expectedFileSize := int64(960)
+	expectedFileSize := int64(956)
 
 	// Looping
 	for i := 0; i < len(errOutput); i++ {
@@ -290,7 +290,7 @@ func TestExportCbz_NoWrap(t *testing.T) {
 	exportDirList = append(exportDirList, validOutputPath)
 	comicInfoList = append(comicInfoList, &validInfo)
 	errMsgList = append(errMsgList, "")
-	expectedFileSize := int64(894)
+	expectedFileSize := int64(889)
 
 	// Create a new app
 	app := NewApp()
@@ -371,7 +371,7 @@ func TestExportCbz_Wrap(t *testing.T) {
 	exportDirList = append(exportDirList, validOutputPath)
 	comicInfoList = append(comicInfoList, &validInfo)
 	errMsgList = append(errMsgList, "")
-	expectedFileSize := int64(894)
+	expectedFileSize := int64(889)
 
 	// Create a new app
 	app := NewApp()

--- a/app_test.go
+++ b/app_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Please note that, the getDirectory method will not be tested
@@ -189,55 +191,51 @@ func TestQuickExportKomga(t *testing.T) {
 //  1. xml.MarshalIndent() not cause any errors
 //  2. *os.File sync() not cause any errors
 func TestExportXml(t *testing.T) {
-	// Prepare list of test case
-	dirInput := make([]string, 0)
-	infoInput := make([]*comicinfo.ComicInfo, 0)
-	textOutput := make([]string, 0)
-
 	// Temp folder creation
 	tempFolder := t.TempDir()
-	// tempFolder := "testing"
 
-	// Check if input comicinfo is nil value
-	dirInput = append(dirInput, tempFolder)
-	infoInput = append(infoInput, nil)
-	textOutput = append(textOutput, "comicinfo is nil value")
+	type testCase struct {
+		dir       string // Only final part of abs path, i.e. no need to include temp folder value
+		c         *comicinfo.ComicInfo
+		hasErrMsg bool
+	}
 
-	// Demo os.Create() error (target directory doesn't exist)
-	dirInput = append(dirInput, filepath.Join(tempFolder, "invalid"))
-	infoInput = append(infoInput, &comicinfo.ComicInfo{})
-	textOutput = append(textOutput, "The system cannot find the path specified")
+	tempInfo := comicinfo.New()
 
-	// Check output xml
-	c := comicinfo.New()
+	tests := []testCase{
+		// 1. Graceful Test
+		{filepath.Join(tempFolder, "case1"), &tempInfo, false},
+		// 2. nil value of ComicInfo
+		{filepath.Join(tempFolder, "case2"), nil, true},
+		// 3. Empty path
+		{"", &tempInfo, true},
+		// 4. Invalid path (invalid character)
+		{filepath.Join(tempFolder, "???"), &tempInfo, true},
+	}
 
-	dirInput = append(dirInput, tempFolder)
-	infoInput = append(infoInput, &c)
-	textOutput = append(textOutput, "")
-
-	// Create a new app
+	// Prepare dummy App
 	app := NewApp()
 
-	for i := 0; i < len(textOutput); i++ {
-		errMsg := app.ExportXml(dirInput[i], infoInput[i])
+	// Start test
+	for idx, tt := range tests {
+		msg := app.ExportXml(tt.dir, tt.c)
 
-		// Check error message
-		if !strings.Contains(errMsg, textOutput[i]) {
-			t.Errorf("Case id = %d: Expected %v, got %v", i, textOutput[i], errMsg)
-		}
+		// Check error
+		assert.EqualValuesf(t, tt.hasErrMsg, msg != "", "Case %d: unexpected error message: %v", idx, msg)
 
-		// Early Return for error cases
-		if textOutput[i] != "" {
+		// Skip file content compare when tests have expected error message
+		if tt.hasErrMsg {
 			continue
 		}
 
-		// Check output xml equals to expected
-		b, err := os.ReadFile(filepath.Join(tempFolder, "ComicInfo.xml"))
+		// Check exported value
+		b, err := os.ReadFile(filepath.Join(tt.dir, "ComicInfo.xml"))
 		if err != nil {
-			t.Errorf("Reading XML in case id %d : %v", i, err)
-		} else if removeExtraSpace(string(b)) != removeExtraSpace(expectedXML) {
-			t.Errorf("Unmatched XML in case id %d: %s vs %s", i, string(b), expectedXML)
+			t.Errorf("Reading XML in case id %d : %v", idx, err)
 		}
+
+		assert.EqualValuesf(t, removeExtraSpace(expectedXML), removeExtraSpace(string(b)),
+			"Case %d: unmatched XML.", idx)
 	}
 }
 

--- a/internal/comicinfo/construct.go
+++ b/internal/comicinfo/construct.go
@@ -1,9 +1,12 @@
 package comicinfo
 
+import "encoding/xml"
+
 // Create a new ComicInfo Instance.
 func New() ComicInfo {
 	return ComicInfo{
-		Xsi: "http://www.w3.org/2001/XMLSchema-instance",
-		Xsd: "http://www.w3.org/2001/XMLSchema",
+		XMLName: xml.Name{Space: "", Local: "ComicInfo"},
+		Xsi:     "http://www.w3.org/2001/XMLSchema-instance",
+		Xsd:     "http://www.w3.org/2001/XMLSchema",
 	}
 }

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -8,6 +8,9 @@ import (
 )
 
 // Check the file is exist or not.
+//
+// Please note that this function will not check filepath valid or not.
+// Developer should use IsFileValid() instead.
 func IsFileExist(path string) bool {
 	_, err := os.Stat(path)
 
@@ -22,5 +25,23 @@ func IsFileExist(path string) bool {
 	}
 
 	logrus.Warnf("Unknown error: %s - %v", path, err)
+	return false
+}
+
+// Check filepath is valid or not.
+//
+// This method will only ignore is actually exist or not,
+// or any permission error,
+// focus on filepath is valid character or not.
+func IsPathValid(path string) bool {
+	_, err := os.Stat(path)
+
+	// Ignore nil error or Not Exist error
+	if err == nil || os.IsNotExist(err) || os.IsPermission(err) {
+		return true
+	}
+
+	// Log Error & return
+	logrus.Debugf("invalid path error: %v", err)
 	return false
 }

--- a/internal/files/files_test.go
+++ b/internal/files/files_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsFileExist(t *testing.T) {
@@ -25,6 +27,7 @@ func TestIsFileExist(t *testing.T) {
 	}{
 		{path1, true},
 		{path2, false},
+		{"???", false},
 	}
 
 	// Start Test
@@ -32,5 +35,33 @@ func TestIsFileExist(t *testing.T) {
 		if got := IsFileExist(tt.path); got != tt.want {
 			t.Errorf("IsFileExist() = %v, want %v", got, tt.want)
 		}
+	}
+}
+
+func TestIsPathValid(t *testing.T) {
+	// Prepare valid path
+	dir := t.TempDir()
+
+	// Struct for perform unit testing
+	type testCase struct {
+		path string // Path to test
+		want bool   // return value
+	}
+
+	// Prepare Test
+	tests := []testCase{
+		// 1. Case for valid & exist path
+		{dir, true},
+		// 2. Case for valid & not exist path
+		{"not exist", true},
+		// 3. Case for invalid path
+		{"???", false},
+	}
+
+	for idx, tt := range tests {
+		got := IsPathValid(tt.path)
+
+		// Check errors
+		assert.EqualValuesf(t, tt.want, got, "Case %d : result unexpected.", idx)
 	}
 }

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -19,7 +19,7 @@ func GetPageInfo(absPath string) (pages []comicinfo.ComicPageInfo, err error) {
 
 	pageInfos := make([]comicinfo.ComicPageInfo, 0)
 
-	// Image must be rescan due to image contents may changed
+	// Image must be re-scan due to image contents may changed
 	imageIdx := 0
 	for _, entry := range entries {
 		ext := filepath.Ext(entry.Name())
@@ -51,7 +51,15 @@ func GetPageInfo(absPath string) (pages []comicinfo.ComicPageInfo, err error) {
 
 // Scan the folderPath as a book/manga, then return comicInfo.
 func ScanBooks(folderPath string) (*comicinfo.ComicInfo, error) {
-	folderName := filepath.Base(folderPath)
+	// Prevent Empty path
+	if folderPath == "" {
+		return nil, fmt.Errorf("empty folder path")
+	}
+
+	// Prevent invalid path
+	if !files.IsPathValid(folderPath) || !files.IsFileExist(folderPath) {
+		return nil, fmt.Errorf("invalid folder path")
+	}
 
 	// Check any comic info file before start parse
 	infoPath := filepath.Join(folderPath, "ComicInfo.xml")
@@ -63,7 +71,7 @@ func ScanBooks(folderPath string) (*comicinfo.ComicInfo, error) {
 			return nil, err
 		}
 
-		// Force Rescan Pages
+		// Force Re-scan Pages
 		pages, err := GetPageInfo(folderPath)
 		if err != nil {
 			return nil, err
@@ -78,6 +86,7 @@ func ScanBooks(folderPath string) (*comicinfo.ComicInfo, error) {
 	c := comicinfo.New()
 
 	// Parse Folder to info
+	folderName := filepath.Base(folderPath)
 	market, author, bookName := parser.ParseFolder(folderName)
 	c.Title = bookName
 	c.Writer = author


### PR DESCRIPTION
### Changes (New Feature)

**New Feature**
- GUI will now load existing comicinfo when selected folder has `ComicInfo.xml`
- Add a new utils `IsPathValid` to check file path valid or not

**app.go**
- Replace old export comicinfo code to `comicinfo.Save` 
- Fix expected file size due to prefix changes in XML
- Rewrite test for `ExportXml`

**Misc**
- Add more words to dictionary
- `comicinfo.New()` will now return struct with `XMLName`

### Related Issues

Close #67.

### Checklist:

#### Code Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request

#### Documentation Checklist:

-   [x] I have add new feature description to README.md of this repository
-   [x] I have add/modify file description to README.md of the package (tick if not applicable)

#### Testing Checklist:

-   [x] I have create new test case / test for new feature
-   [x] I have run all new & existing test and pass locally with my changes
