### PR TITLE
Use `react-select` in tag input

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Currently, this feature support below fields:
 
 -   `Genre`
 -   `Publisher`
+-   `Tags`
 
 More field will be added in near future.
 

--- a/frontend/src/forms/OptionFormRow.tsx
+++ b/frontend/src/forms/OptionFormRow.tsx
@@ -26,6 +26,8 @@ type OptionFormRowProps = {
 	getDefaultOpt: () => Promise<application.HistoryResp>;
 	/** Max height for menu list, same with css `max-height`. Default is `9em` */
 	menuMaxHeight?: string;
+	/** Current height for component, same with css `height`.*/
+	componentHeight?: string;
 };
 
 /** Create a uniform Form.Group Element as Row, which contains select component that allow create new options. */
@@ -37,6 +39,7 @@ export default function OptionFormRow({
 	setValue,
 	getDefaultOpt,
 	menuMaxHeight,
+	componentHeight,
 }: Readonly<OptionFormRowProps>) {
 	/** Interface for react-select option. */
 	interface SelectOption {
@@ -159,6 +162,12 @@ export default function OptionFormRow({
 			...baseStyles,
 			backgroundColor: "transparent",
 			borderStyle: "none",
+			height: componentHeight ?? baseStyles.height,
+			alignItems: componentHeight === null ? baseStyles.alignItems : "flex-start",
+		}),
+		indicatorsContainer: (baseStyles) => ({
+			...baseStyles,
+			alignItems: componentHeight === null ? baseStyles.alignItems : "flex-start",
 		}),
 		indicatorSeparator: (baseStyles) => ({
 			...baseStyles,

--- a/frontend/src/forms/OptionFormRow.tsx
+++ b/frontend/src/forms/OptionFormRow.tsx
@@ -24,8 +24,8 @@ type OptionFormRowProps = {
 	setValue?: (value: string) => void;
 	/** Function to get default values from wails backend. */
 	getDefaultOpt: () => Promise<application.HistoryResp>;
-	/** Current height for menu list, same with css `height`. Default is `9em` */
-	height?: string;
+	/** Max height for menu list, same with css `max-height`. Default is `9em` */
+	menuMaxHeight?: string;
 };
 
 /** Create a uniform Form.Group Element as Row, which contains select component that allow create new options. */
@@ -36,7 +36,7 @@ export default function OptionFormRow({
 	disabled,
 	setValue,
 	getDefaultOpt,
-	height,
+	menuMaxHeight,
 }: Readonly<OptionFormRowProps>) {
 	/** Interface for react-select option. */
 	interface SelectOption {
@@ -189,7 +189,7 @@ export default function OptionFormRow({
 		}),
 		menuList: (baseStyles) => ({
 			...baseStyles,
-			height: height ?? "9em",
+			maxHeight: menuMaxHeight ?? "9em",
 		}),
 		option: (baseStyles) => ({
 			...baseStyles,

--- a/frontend/src/pages/metadata/TagMetadata.tsx
+++ b/frontend/src/pages/metadata/TagMetadata.tsx
@@ -1,114 +1,29 @@
-// React
-import { ChangeEvent, useState } from "react";
-
 // React Component
-import { Button, Col, Form, Row } from "react-bootstrap";
+import { Form } from "react-bootstrap";
 
 // Project Specified Component
-import { TagsArea } from "../../components/Tags";
+import OptionFormRow from "../../forms/OptionFormRow";
 import { MetadataProps } from "./MetadataProps";
+
+// Wails binding
+import { GetAllTagInput } from "../../../wailsjs/go/application/App";
 
 /**
  * The interface for show/edit tags metadata.
  * @returns JSX Element
  */
 export default function TagMetadata({ comicInfo: info, infoSetter }: Readonly<MetadataProps>) {
-	/** Hooks of tag that to be added. Only allow single tag to be added at a time. */
-	const [singleTag, setSingleTag] = useState<string>("");
-
-	/** Function for handing enter key pressed when entering custom tags. */
-	const handleKeyDown = (event: React.KeyboardEvent) => {
-		if (event.key === "Enter") {
-			event.preventDefault();
-			handleAdd();
-		}
-	};
-
-	/**
-	 * Function to handle the textfield of tag to be added.
-	 * @param e the react event
-	 */
-	function handleChanges(e: ChangeEvent<HTMLInputElement>) {
-		setSingleTag(e.target.value);
-	}
-
-	/** Function for handling add button click */
-	function handleAdd() {
-		// Prevent Empty tags
-		if (singleTag === "") {
-			return;
-		}
-
-		// Retrieve Tags
-		let temp = info?.Tags;
-
-		// Append Tags to comic info
-		if (temp === "" || temp === undefined) {
-			temp = singleTag;
-		} else {
-			temp += ", " + singleTag;
-		}
-
-		// Apply Change to ComicInfo
-		infoSetter("Tags", temp);
-
-		// Empty Tags in textfield
-		setSingleTag("");
-	}
-
-	/** Function for handling delete button click */
-	function handleDelete(id: number) {
-		if (info?.Tags === undefined) {
-			return;
-		}
-
-		// Parse tags to array of strings
-		let array = info.Tags.split(",");
-
-		// Remove tag by index
-		array.splice(id, 1);
-
-		// Concat array of string to string
-		let str = array.join(", ");
-
-		// Set by info setter
-		infoSetter("Tags", str);
-	}
-
 	return (
 		<div>
 			<Form>
-				{/* A Text Area for holding lines of tags. */}
-				<Row>
-					<Col sm={2} className="mt-1">
-						{"Tags"}
-					</Col>
-					<Col sm={9}>
-						<TagsArea rawTags={info?.Tags} handleDelete={handleDelete} />
-					</Col>
-				</Row>
-
-				{/* Empty Rows for margin */}
-				<Row className="mb-3" />
-
-				<Row>
-					{/* Empty Column */}
-					<Col sm={2} className="mt-1">
-						Add Custom Tag
-					</Col>
-
-					{/* Column of adding tags */}
-					<Col sm={8}>
-						<Form.Control value={singleTag} onChange={handleChanges} onKeyDown={handleKeyDown} />
-					</Col>
-
-					{/* Column of add button */}
-					<Col sm={1}>
-						<Button variant="outline-info" onClick={handleAdd}>
-							Add
-						</Button>
-					</Col>
-				</Row>
+				<OptionFormRow
+					title={"Tags"}
+					value={info?.Tags}
+					setValue={(val) => infoSetter("Tags", val)}
+					getDefaultOpt={GetAllTagInput}
+					componentHeight="200px"
+					menuMaxHeight="16em"
+				/>
 			</Form>
 		</div>
 	);

--- a/frontend/wailsjs/go/application/App.d.ts
+++ b/frontend/wailsjs/go/application/App.d.ts
@@ -12,6 +12,8 @@ export function GetAllGenreInput():Promise<application.HistoryResp>;
 
 export function GetAllPublisherInput():Promise<application.HistoryResp>;
 
+export function GetAllTagInput():Promise<application.HistoryResp>;
+
 export function GetComicInfo(arg1:string):Promise<application.ComicInfoResponse>;
 
 export function GetDirectory():Promise<string>;

--- a/frontend/wailsjs/go/application/App.js
+++ b/frontend/wailsjs/go/application/App.js
@@ -18,6 +18,10 @@ export function GetAllPublisherInput() {
   return window['go']['application']['App']['GetAllPublisherInput']();
 }
 
+export function GetAllTagInput() {
+  return window['go']['application']['App']['GetAllTagInput']();
+}
+
 export function GetComicInfo(arg1) {
   return window['go']['application']['App']['GetComicInfo'](arg1);
 }

--- a/internal/README.md
+++ b/internal/README.md
@@ -39,3 +39,9 @@ Currently Support `Author`, `Title`, also for identify special tags.
 The package for scanner image directory.
 
 This package will produce a `ComicInfo` Struct, which contains pages detail, and also information that extract from `parser` package.
+
+## tagger
+
+Package for handle tags record in database, include user inputted values.
+
+This package is separate from `history` package due to tags handling can be complex when compare with other user inputted values.

--- a/internal/application/export.go
+++ b/internal/application/export.go
@@ -6,6 +6,7 @@ import (
 	"gui-comicinfo/internal/comicinfo"
 	"gui-comicinfo/internal/history"
 	"gui-comicinfo/internal/scanner"
+	"gui-comicinfo/internal/tagger"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,13 +69,21 @@ func (a *App) QuickExportKomga(folder string) string {
 // Save user input to history database.
 // All comicinfo handling logic should be inside this function.
 func (a *App) saveToHistory(c *comicinfo.ComicInfo) error {
+	// ==================== Tags ====================
+	// Split the tags into slice of string by comma
+	s := strings.Split(c.Tags, ",")
+	err := tagger.AddTag(a.DB, s...)
 
+	if err != nil {
+		return err
+	}
+
+	// ========== For values supported by history pkg ============
 	values := make([]history.HistoryVal, 0)
 
 	//  ------------- Genre ----------------
-
 	// Split the genre into slice of string by comma
-	s := strings.Split(c.Genre, ",")
+	s = strings.Split(c.Genre, ",")
 	for _, item := range s {
 		values = append(values, history.HistoryVal{
 			Category: history.Genre_Text,

--- a/internal/application/history.go
+++ b/internal/application/history.go
@@ -1,6 +1,9 @@
 package application
 
-import "gui-comicinfo/internal/history"
+import (
+	"gui-comicinfo/internal/history"
+	"gui-comicinfo/internal/tagger"
+)
 
 // Struct that designed for
 // send last input record from history module to frontend.
@@ -23,6 +26,17 @@ func (a *App) GetAllGenreInput() HistoryResp {
 // Get all user inputted publisher from database.
 func (a *App) GetAllPublisherInput() HistoryResp {
 	list, err := history.GetPublisherList(a.DB)
+
+	if err != nil {
+		return HistoryResp{nil, err.Error()}
+	}
+
+	return HistoryResp{list, ""}
+}
+
+// Get all user inputted tag from database.
+func (a *App) GetAllTagInput() HistoryResp {
+	list, err := tagger.GetAllTags(a.DB)
 
 	if err != nil {
 		return HistoryResp{nil, err.Error()}

--- a/internal/tagger/db.go
+++ b/internal/tagger/db.go
@@ -1,0 +1,78 @@
+// Package for manipulating tags in comic info.
+package tagger
+
+import (
+	"fmt"
+	"gui-comicinfo/internal/database"
+)
+
+// Error blocks
+var (
+	// Error when trying to use nil database in this module.
+	ErrAppDBNil = fmt.Errorf("AppDB cannot be nil")
+)
+
+// Add tags to given AppDB. This function support multiple tags insert at once.
+//
+// If tag value is empty string, then it will be skipped.
+func AddTag(db *database.AppDB, tags ...string) error {
+	// Prevent nil database
+	if db == nil {
+		return ErrAppDBNil
+	}
+
+	// Prepare statement
+	stmt, err := db.Prepare("INSERT OR IGNORE INTO tags (input) VALUES (?)")
+	if err != nil {
+		return err
+	}
+
+	// Insert multiple value
+	for _, item := range tags {
+		// Skip empty string values
+		if item == "" {
+			continue
+		}
+
+		_, err = stmt.Exec(item)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Get all tags from given AppDB.
+func GetAllTags(db *database.AppDB) ([]string, error) {
+	// Prevent nil database
+	if db == nil {
+		return []string{}, ErrAppDBNil
+	}
+
+	// Prepare SQL & its args
+	query := "SELECT input FROM tags ORDER BY input"
+
+	// Prepare query
+	stmt, err := db.Prepare(query)
+	if err != nil {
+		return nil, err
+	}
+
+	// Execute query
+	rows, err := stmt.Query()
+	if err != nil {
+		return nil, err
+	}
+
+	// Load query result
+	list := make([]string, 0)
+	for rows.Next() {
+		var input string
+		rows.Scan(&input)
+
+		list = append(list, input)
+	}
+
+	return list, nil
+}

--- a/internal/tagger/db_test.go
+++ b/internal/tagger/db_test.go
@@ -1,0 +1,198 @@
+// Package for manipulating tags in comic info.
+package tagger
+
+import (
+	"gui-comicinfo/internal/database"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Create a new AppDB with database file,
+// and ensure that AppDB is connected & update to latest schema.
+//
+// Developer should ensure returned AppDB will be closed after usage.
+//
+// If filename is empty string, a nil AppDB will be returned.
+func getAppDB(dir, filename string) (*database.AppDB, error) {
+	// Return nil if filename is empty string
+	if filename == "" {
+		return nil, nil
+	}
+
+	db, err := database.NewPathDB(filepath.Join(dir, filename))
+	if err != nil {
+		return nil, err
+	}
+
+	// Connect database
+	db.Connect()
+	db.StepToLatest()
+
+	// Return db
+	return db, nil
+}
+
+// Create a test database with some value inserted.
+//
+// // Developer should ensure returned AppDB will be closed after usage.
+func createTestDB(path string) (*database.AppDB, error) {
+	a, err := database.NewPathDB(path)
+	if err != nil {
+		return nil, err
+	}
+
+	a.Connect()
+	a.StepToLatest()
+
+	// Insert data rows
+	sql := `INSERT INTO tags (input) VALUES ('abc'), ('def'), ('ghi')`
+	stmt, err := a.Prepare(sql)
+	if err != nil {
+		return nil, err
+	}
+	stmt.Exec()
+
+	// Return closed db object
+	return a, nil
+}
+
+// Function to check how many rows in db has given tag.
+func checkRowCount(a *database.AppDB, value string) (int, error) {
+	// Get Inserted rows
+	stmt, err := a.Prepare("SELECT COUNT(*) FROM tags WHERE input=?")
+	if err != nil {
+		return -1, err
+	}
+
+	// Execute query
+	rows, err := stmt.Query(value)
+	if err != nil {
+		return -1, err
+	}
+
+	// Load query result
+	var count int
+	for rows.Next() {
+		rows.Scan(&count)
+	}
+
+	return count, nil
+}
+
+func TestAddTag(t *testing.T) {
+	// Directory to store db files
+	dir := t.TempDir()
+
+	// Test case
+	type testCase struct {
+		dbPath      string
+		tags        []string
+		wantErr     bool
+		insertedRow []int // Should have same order as `tags`
+	}
+
+	tests := []testCase{
+		// Normal Test
+		{"test1.db", []string{"abc"}, false, []int{1}},
+		{"test2.db", []string{"abc", "def"}, false, []int{1, 1}},
+
+		// Duplication Test
+		{"test-duplicate.db", []string{"abc", "abc"}, false, []int{1, 1}},
+
+		// Empty string
+		{"test3.db", []string{""}, false, []int{0}},
+		{"test4.db", []string{"abc", ""}, false, []int{1, 0}},
+
+		// Nil Database
+		{"", []string{"abc"}, true, []int{1}},
+	}
+
+	for idx, tt := range tests {
+		// Create new database
+		db, err := getAppDB(dir, tt.dbPath)
+		if err != nil {
+			t.Errorf("Failed to create database: %v", err)
+		}
+
+		if db != nil {
+			defer db.Close()
+		}
+
+		// Perform function
+		err = AddTag(db, tt.tags...)
+
+		// Asset no error occur
+		assert.EqualValuesf(t, tt.wantErr, err != nil, "Case %d: Expected has error=%t, got %t", idx, tt.wantErr, err != nil)
+		if tt.wantErr {
+			continue
+		}
+
+		// Asset value has inserted
+		for i, val := range tt.tags {
+			count, err := checkRowCount(db, val)
+			if err != nil {
+				t.Errorf("Failed to check row count: %v", err)
+			}
+
+			assert.EqualValuesf(t, tt.insertedRow[i], count, "Case %d: Expected inserted=%d, got %d", idx, tt.insertedRow[i], count)
+		}
+	}
+}
+
+func TestGetAllTags(t *testing.T) {
+	// Directory to store db files
+	dir := t.TempDir()
+
+	// A standard test database will be created
+	a, err := createTestDB(filepath.Join(dir, "test_get.db"))
+	if err != nil {
+		t.Errorf("Failed to create db: %v", err)
+	}
+
+	if a != nil {
+		defer a.Close()
+	}
+
+	// Empty database
+	empty, err := database.NewPathDB(filepath.Join(dir, "test_get_empty.db"))
+	if err != nil {
+		t.Errorf("Failed to create db: %v", err)
+	}
+
+	if empty != nil {
+		empty.Connect()
+		empty.StepToLatest()
+		defer empty.Close()
+	}
+
+	// Test case
+	type testCase struct {
+		db      *database.AppDB
+		results []string
+		wantErr bool
+	}
+
+	tests := []testCase{
+		// Normal Case
+		{a, []string{"abc", "def", "ghi"}, false},
+
+		// Empty result
+		{empty, []string{}, false},
+
+		// Nil database
+		{nil, []string{}, true},
+	}
+
+	// Start testing
+	for idx, tt := range tests {
+		results, err := GetAllTags(tt.db)
+
+		// Check error
+		assert.EqualValuesf(t, tt.wantErr, err != nil, "case %d: expected error=%v, but error=%v", idx, tt.wantErr, err)
+
+		// Check values
+		assert.EqualValuesf(t, tt.results, results, "case %d: unexpected output, expect=%v, got=%v", idx, tt.results, results)
+	}
+}


### PR DESCRIPTION
### Changes (New Feature)

- Replace tag input by `react-select`
   - Separate max menu height & component height in `OptionFormRow`
- Support save tag input result into database
- Add function for get tags in database in `application` package 

### Related Issues

Close #54.

### Checklist:

#### Code Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request

#### Documentation Checklist:

-   [x] I have add new feature description to README.md of this repository
-   [x] I have add/modify file description to README.md of the package (tick if not applicable)

#### Testing Checklist:

-   [x] I have create new test case / test for new feature
-   [x] I have run all new & existing test and pass locally with my changes
