### PR TITLE
Improve `archive` package logic

### DIFF
--- a/internal/application/export.go
+++ b/internal/application/export.go
@@ -164,7 +164,7 @@ func (a *App) ExportCbz(inputDir string, exportDir string, c *comicinfo.ComicInf
 	// Save ComicInfo.xml
 	err := comicinfo.Save(c, filepath.Join(inputDir, "ComicInfo.xml"))
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
+		fmt.Printf("error when save: %v\n", err)
 		return err.Error()
 	}
 
@@ -175,10 +175,16 @@ func (a *App) ExportCbz(inputDir string, exportDir string, c *comicinfo.ComicInf
 	}
 
 	// Start Archive
-	filename, _ := archive.CreateZipTo(inputDir, exportDir)
+	filename, err := archive.CreateZipTo(inputDir, exportDir)
+	if err != nil {
+		fmt.Printf("error when zip: %v\n", err)
+		return err.Error()
+	}
+	fmt.Printf("Filename: %s\n", filename)
+
 	err = archive.RenameZip(filename, isWrap)
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
+		fmt.Printf("error when rename: %v\n", err)
 		return err.Error()
 	}
 	return ""

--- a/internal/archive/rename_test.go
+++ b/internal/archive/rename_test.go
@@ -6,26 +6,34 @@ import (
 	"testing"
 )
 
+const (
+	_testZip = "hello.zip"
+	_testCbz = "hello.cbz"
+)
+
 // Test Rename Zip archive to .cbz archive, with wrap option is enabled.
-func TestRenameZip_Wrap(t *testing.T) {
+func TestRenameZipWrap(t *testing.T) {
 	// Create a temp directory
 	tempDir := t.TempDir()
 
 	// Create a folder inside temp directory
 	os.MkdirAll(filepath.Join(tempDir, "tmp"), 0755)
 
+	// Prepare zip path
+	zipPath := filepath.Join(tempDir, "tmp", _testZip)
+
 	// Create a zip file
-	file1, _ := os.Create(filepath.Join(tempDir, "tmp", "hello.zip"))
+	file1, _ := os.Create(zipPath)
 	file1.Close()
 
 	// Test Function
-	err := RenameZip(filepath.Join(tempDir, "tmp", "hello.zip"), true)
+	err := RenameZip(zipPath, true)
 	if err != nil {
 		t.Error(err)
 	}
 
 	// Result Verify
-	dest, openErr := os.Open(filepath.Join(tempDir, "tmp", "hello", "hello.cbz"))
+	dest, openErr := os.Open(filepath.Join(tempDir, "tmp", "hello", _testCbz))
 	if openErr != nil {
 		t.Error(openErr)
 	}
@@ -33,25 +41,28 @@ func TestRenameZip_Wrap(t *testing.T) {
 }
 
 // Test Rename Zip archive to .cbz archive, with wrap options is disabled
-func TestRenameZip_NoWrap(t *testing.T) {
+func TestRenameZipNoWrap(t *testing.T) {
 	// Create a temp directory
 	tempDir := t.TempDir()
 
 	// Create a folder inside temp directory
 	os.MkdirAll(filepath.Join(tempDir, "tmp"), 0755)
 
+	// Prepare zip path
+	zipPath := filepath.Join(tempDir, "tmp", _testZip)
+
 	// Create a zip file
-	file1, _ := os.Create(filepath.Join(tempDir, "tmp", "hello.zip"))
+	file1, _ := os.Create(zipPath)
 	file1.Close()
 
 	// Test Function
-	err := RenameZip(filepath.Join(tempDir, "tmp", "hello.zip"), false)
+	err := RenameZip(zipPath, false)
 	if err != nil {
 		t.Error(err)
 	}
 
 	// Result Verify
-	dest, openErr := os.Open(filepath.Join(tempDir, "tmp", "hello.cbz"))
+	dest, openErr := os.Open(filepath.Join(tempDir, "tmp", _testCbz))
 	if openErr != nil {
 		t.Error(openErr)
 	}

--- a/internal/archive/zip.go
+++ b/internal/archive/zip.go
@@ -18,13 +18,25 @@ func CreateZip(folderToAdd string) (dest string, err error) {
 func CreateZipTo(inputDir string, destDir string) (dest string, err error) {
 	destFileName := filepath.Base(inputDir)
 
-	// Create ZIP File
-	destFile, err := createArchive(inputDir, destDir, destFileName)
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "comicinfo-zip-*")
 	if err != nil {
-		return destFile, err
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create ZIP File
+	tmpFile, err := createArchive(inputDir, tmpDir, destFileName)
+	if err != nil {
+		return tmpFile, err
 	}
 
-	return filepath.Join(destDir, destFileName+".zip"), nil
+	// Move zip in temp folder to dest directory
+	newPath := filepath.Join(destDir, destFileName+".zip")
+	os.Rename(tmpFile, newPath)
+
+	// Return dest file path
+	return newPath, nil
 }
 
 // Create archive to temporary directory by given input directory & its content.

--- a/internal/archive/zip.go
+++ b/internal/archive/zip.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"archive/zip"
+	"gui-comicinfo/internal/files"
 	"io"
 	"os"
 	"path/filepath"
@@ -33,10 +34,9 @@ func CreateZipTo(inputDir string, destDir string) (dest string, err error) {
 
 	// Move zip in temp folder to dest directory
 	newPath := filepath.Join(destDir, destFileName+".zip")
-	os.Rename(tmpFile, newPath)
 
 	// Return dest file path
-	return newPath, nil
+	return newPath, files.MoveFile(tmpFile, newPath)
 }
 
 // Create archive to temporary directory by given input directory & its content.

--- a/internal/archive/zip.go
+++ b/internal/archive/zip.go
@@ -9,55 +9,7 @@ import (
 
 // Create ZIP File inside folderToAdd.
 func CreateZip(folderToAdd string) (dest string, err error) {
-	destFileName := filepath.Base(folderToAdd)
-
-	// Create ZIP File
-	destFile, err := os.Create(filepath.Join(folderToAdd, destFileName+".zip"))
-	if err != nil {
-		return "", err
-	}
-	defer destFile.Close()
-
-	// Zip Writer
-	destZip := zip.NewWriter(destFile)
-	defer destZip.Close()
-
-	// Load File Entries inside folderToAdd
-	entries, err := os.ReadDir(folderToAdd)
-	if err != nil {
-		return "", err
-	}
-
-	// Loop File inside folderToAdd
-	for _, entry := range entries {
-		filename := entry.Name()
-
-		// Skip Zip file
-		if filename == destFileName+".zip" {
-			continue
-		}
-
-		// Create File inside zip
-		zipFile, err := destZip.Create(filename)
-		if err != nil {
-			return "", err
-		}
-
-		// Open Actual File
-		file, err := os.Open(filepath.Join(folderToAdd, entry.Name()))
-		if err != nil {
-			return "", err
-		}
-		defer file.Close()
-
-		// Copy file content
-		_, err = io.Copy(zipFile, file)
-		if err != nil {
-			return "", err
-		}
-	}
-
-	return filepath.Join(folderToAdd, destFileName+".zip"), nil
+	return CreateZipTo(folderToAdd, folderToAdd)
 }
 
 // Create ZIP File of inputDir, and output the zip to destDir.

--- a/internal/archive/zip_test.go
+++ b/internal/archive/zip_test.go
@@ -7,16 +7,23 @@ import (
 	"testing"
 )
 
+const (
+	_img1File = "image1.jpg"
+	_img2File = "image2.jpg"
+	_img3File = "image3.jpg"
+	_xmlFile  = "test.xml"
+)
+
 // Test Create Zip from folder
 func TestCreateZip(t *testing.T) {
 	// Create a temp directory
 	tempDir := t.TempDir()
 
 	// Create a set of file
-	file1, _ := os.Create(filepath.Join(tempDir, "image1.jpg"))
-	file2, _ := os.Create(filepath.Join(tempDir, "image2.jpg"))
-	file3, _ := os.Create(filepath.Join(tempDir, "image3.jpg"))
-	file4, _ := os.Create(filepath.Join(tempDir, "test.xml"))
+	file1, _ := os.Create(filepath.Join(tempDir, _img1File))
+	file2, _ := os.Create(filepath.Join(tempDir, _img2File))
+	file3, _ := os.Create(filepath.Join(tempDir, _img3File))
+	file4, _ := os.Create(filepath.Join(tempDir, _xmlFile))
 	defer file1.Close()
 	defer file2.Close()
 	defer file3.Close()
@@ -46,18 +53,24 @@ func TestCreateZip(t *testing.T) {
 		list[f.Name] = 1
 	}
 
-	_, exist1 := list["test.xml"]
-	_, exist2 := list["image1.jpg"]
-	_, exist3 := list["image2.jpg"]
-	_, exist4 := list["image3.jpg"]
+	_, exist1 := list[_xmlFile]
+	_, exist2 := list[_img1File]
+	_, exist3 := list[_img2File]
+	_, exist4 := list[_img3File]
 
 	if !exist1 {
 		t.Error("Content 1 missing in zip")
-	} else if !exist2 {
+	}
+
+	if !exist2 {
 		t.Error("Content 2 missing in zip")
-	} else if !exist3 {
+	}
+
+	if !exist3 {
 		t.Error("Content 3 missing in zip")
-	} else if !exist4 {
+	}
+
+	if !exist4 {
 		t.Error("Content 4 missing in zip")
 	}
 }
@@ -75,10 +88,10 @@ func TestCreateZipTo(t *testing.T) {
 	os.MkdirAll(outputDir, 0755)
 
 	// Create a set of file
-	file1, _ := os.Create(filepath.Join(inputDir, "image1.jpg"))
-	file2, _ := os.Create(filepath.Join(inputDir, "image2.jpg"))
-	file3, _ := os.Create(filepath.Join(inputDir, "image3.jpg"))
-	file4, _ := os.Create(filepath.Join(inputDir, "test.xml"))
+	file1, _ := os.Create(filepath.Join(inputDir, _img1File))
+	file2, _ := os.Create(filepath.Join(inputDir, _img2File))
+	file3, _ := os.Create(filepath.Join(inputDir, _img3File))
+	file4, _ := os.Create(filepath.Join(inputDir, _xmlFile))
 	defer file1.Close()
 	defer file2.Close()
 	defer file3.Close()
@@ -108,18 +121,24 @@ func TestCreateZipTo(t *testing.T) {
 		list[f.Name] = 1
 	}
 
-	_, exist1 := list["test.xml"]
-	_, exist2 := list["image1.jpg"]
-	_, exist3 := list["image2.jpg"]
-	_, exist4 := list["image3.jpg"]
+	_, exist1 := list[_xmlFile]
+	_, exist2 := list[_img1File]
+	_, exist3 := list[_img2File]
+	_, exist4 := list[_img3File]
 
 	if !exist1 {
 		t.Error("Content 1 missing in zip")
-	} else if !exist2 {
+	}
+
+	if !exist2 {
 		t.Error("Content 2 missing in zip")
-	} else if !exist3 {
+	}
+
+	if !exist3 {
 		t.Error("Content 3 missing in zip")
-	} else if !exist4 {
+	}
+
+	if !exist4 {
 		t.Error("Content 4 missing in zip")
 	}
 }


### PR DESCRIPTION
### Changes Made

- Use OS temp folder when generate archive, which solve #90 
- Migrate `CreateZip()` by `CreateZipTo()`, for code reuse
- Fix error handling on `archive` package
- Improve testing on `archive` package
- Add move file utility

### Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have create/modify corresponding test for new changes
-   [x] I have made corresponding changes to the documentation
-   [x] I have run all new & existing test and pass locally with my changes
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request
