### PR TITLE
Update deps and fix schema version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module gui-comicinfo
 go 1.23.1
 
 require (
-	github.com/dark-person/lazydb v0.1.3
+	github.com/dark-person/lazydb v0.1.5
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 	github.com/wailsapp/wails/v2 v2.9.2

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
 github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
-github.com/dark-person/lazydb v0.1.3 h1:ZjMMxRmXW0KbwR7tZ8QT6oNL8lCeRCNBpU/7JfYZKic=
-github.com/dark-person/lazydb v0.1.3/go.mod h1:5YakMfYNfg78SRqT9nW+QqpBvE7Q4VOHipH+rpfc/hc=
+github.com/dark-person/lazydb v0.1.5 h1:3KoIkNGZjDEwXsyEb8iq44Pg0kn97hMtsKWFoAvD9fY=
+github.com/dark-person/lazydb v0.1.5/go.mod h1:5YakMfYNfg78SRqT9nW+QqpBvE7Q4VOHipH+rpfc/hc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/assets/embed.go
+++ b/internal/assets/embed.go
@@ -21,6 +21,6 @@ func DefaultDb(path string) *lazydb.LazyDB {
 	return lazydb.New(
 		lazydb.DbPath(path),
 		lazydb.Migrate(schema, "schema"),
-		lazydb.Version(0),
+		lazydb.Version(1),
 	)
 }


### PR DESCRIPTION
Update `lazydb` to v0.1.5, fix schema version to 1.

### Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have create/modify corresponding test for new changes
-   [x] I have made corresponding changes to the documentation
-   [x] I have run all new & existing test and pass locally with my changes
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request
