### PR TITLE
Fix history module still use string to insert/select

### DIFF
--- a/internal/application/export.go
+++ b/internal/application/export.go
@@ -86,7 +86,7 @@ func (a *App) saveToHistory(c *comicinfo.ComicInfo) error {
 	s = strings.Split(c.Genre, ",")
 	for _, item := range s {
 		values = append(values, history.HistoryVal{
-			Category: history.Genre_Text,
+			Category: history.CategoryGenre,
 			Value:    item,
 		})
 	}
@@ -96,7 +96,7 @@ func (a *App) saveToHistory(c *comicinfo.ComicInfo) error {
 	s = strings.Split(c.Publisher, ",")
 	for _, item := range s {
 		values = append(values, history.HistoryVal{
-			Category: history.Publisher_Text,
+			Category: history.CategoryPublisher,
 			Value:    item,
 		})
 	}

--- a/internal/history/core.go
+++ b/internal/history/core.go
@@ -14,7 +14,7 @@ var (
 )
 
 // Insert value into database. This function is allowed to insert multiple values at once.
-func insertValue(db *lazydb.LazyDB, category string, value ...string) error {
+func insertValue(db *lazydb.LazyDB, category categoryType, value ...string) error {
 	// Prevent nil database
 	if db == nil {
 		return ErrDatabaseNil
@@ -42,7 +42,7 @@ func insertValue(db *lazydb.LazyDB, category string, value ...string) error {
 }
 
 // Get inputted list from database, by given category.
-func getHistory(db *lazydb.LazyDB, category string) ([]string, error) {
+func getHistory(db *lazydb.LazyDB, category categoryType) ([]string, error) {
 	// Prevent nil database
 	if db == nil {
 		return []string{}, ErrDatabaseNil

--- a/internal/history/core_test.go
+++ b/internal/history/core_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Function to check how many rows in db has given category & value.
-func checkRowCount(a *lazydb.LazyDB, category string, value string) (int, error) {
+func checkRowCount(a *lazydb.LazyDB, category categoryType, value string) (int, error) {
 	// Get Inserted rows
 	rows, err := a.Query("SELECT COUNT(*) FROM list_inputted WHERE category=? AND input=?", category, value)
 	if err != nil {
@@ -47,7 +47,7 @@ func createTestDB(path string, withData bool) (*lazydb.LazyDB, error) {
 	}
 
 	// Insert data rows
-	sql := `INSERT INTO list_inputted (category, input) VALUES ('abc','123'), ('def', '123'), ('def', '456')`
+	sql := `INSERT INTO list_inputted (category, input) VALUES (45,'123'), (56, '123'), (56, '456')`
 	_, err = a.Exec(sql)
 	if err != nil {
 		return nil, err
@@ -70,31 +70,31 @@ func TestInsertValue(t *testing.T) {
 	// Test case
 	type testCase struct {
 		dbPath      string
-		category    string
+		category    categoryType
 		value       []string
 		wantErr     bool
 		insertedRow []int // Should have same order as `value`
 	}
 
 	tests := []testCase{
-		// Normal test in  same db
-		{db1, "abc", []string{"123"}, false, []int{1}},
-		{db1, "abc", []string{"123"}, false, []int{1}},
-		{db1, "def", []string{"123"}, false, []int{1}},
+		// Normal test in same db
+		{db1, 45, []string{"123"}, false, []int{1}},
+		{db1, 45, []string{"123"}, false, []int{1}},
+		{db1, 56, []string{"123"}, false, []int{1}},
 
 		// Duplicate Test
-		{"test2.db", "abc", []string{"123", "123"}, false, []int{1, 1}},
-		{"test2.db", "abc", []string{"123", "456"}, false, []int{1, 1}},
+		{"test2.db", 45, []string{"123", "123"}, false, []int{1, 1}},
+		{"test2.db", 45, []string{"123", "456"}, false, []int{1, 1}},
 
 		// Empty value
-		{"test3.db", "abc", []string{}, false, []int{}},
-		{"test4.db", "", []string{"123"}, false, []int{1}},
+		{"test3.db", 45, []string{}, false, []int{}},
+		{"test4.db", 0, []string{"123"}, false, []int{1}},
 
 		// Empty string value
-		{"test5.db", "abc", []string{"123", ""}, false, []int{1, 0}},
+		{"test5.db", 45, []string{"123", ""}, false, []int{1, 0}},
 
 		// Nil database
-		{"", "abc", []string{"123"}, true, []int{1}},
+		{"", 45, []string{"123"}, true, []int{1}},
 	}
 
 	// Start testing
@@ -149,15 +149,15 @@ func TestGetHistory(t *testing.T) {
 
 	// Prepare test case
 	type testCase struct {
-		category string
+		category categoryType
 		result   []string
 		wantErr  bool
 	}
 
 	tests := []testCase{
-		{"abc", []string{"123"}, false},
-		{"def", []string{"123", "456"}, false},
-		{"kk", []string{}, false},
+		{45, []string{"123"}, false},
+		{56, []string{"123", "456"}, false},
+		{77, []string{}, false},
 	}
 
 	// Start Testing
@@ -178,13 +178,13 @@ func TestGetHistoryNilDB(t *testing.T) {
 
 	// Prepare test case
 	type testCase struct {
-		category string
+		category categoryType
 		result   []string
 		wantErr  bool
 	}
 
 	tests := []testCase{
-		{"abc", []string{"123"}, true},
+		{45, []string{"123"}, true},
 	}
 
 	// Start Testing

--- a/internal/history/impl.go
+++ b/internal/history/impl.go
@@ -4,28 +4,30 @@ import (
 	"github.com/dark-person/lazydb"
 )
 
-// Database value for Genre.
-const Genre_Text = "Genre"
+type categoryType int
 
-// Database value for Publisher.
-const Publisher_Text = "Publisher"
+const (
+	CategoryGenre      categoryType = iota + 1 // Database value for Genre.
+	CategoryPublisher                          // Database value for Publisher.
+	CategoryTranslator                         // Database value for Translator.
+)
 
 // Insert genre value from database.
 func InsertGenre(db *lazydb.LazyDB, value ...string) error {
-	return insertValue(db, Genre_Text, value...)
+	return insertValue(db, CategoryGenre, value...)
 }
 
 // Get all genre value that from database.
 func GetGenreList(db *lazydb.LazyDB) ([]string, error) {
-	return getHistory(db, Genre_Text)
+	return getHistory(db, CategoryGenre)
 }
 
 // Insert publisher value from database.
 func InsertPublisher(db *lazydb.LazyDB, value ...string) error {
-	return insertValue(db, Publisher_Text, value...)
+	return insertValue(db, CategoryPublisher, value...)
 }
 
 // Get all publisher value that from database.
 func GetPublisherList(db *lazydb.LazyDB) ([]string, error) {
-	return getHistory(db, Publisher_Text)
+	return getHistory(db, CategoryPublisher)
 }

--- a/internal/history/multiple_test.go
+++ b/internal/history/multiple_test.go
@@ -27,26 +27,25 @@ func TestInsertMultiple(t *testing.T) {
 
 	tests := []testCase{
 		// Normal test in same db
-		{db1, []HistoryVal{{"abc", "123"}}, false, []int{1}},
-		{db1, []HistoryVal{{"abc", "123"}}, false, []int{1}},
-		{db1, []HistoryVal{{"def", "123"}}, false, []int{1}},
+		{db1, []HistoryVal{{34, "123"}}, false, []int{1}},
+		{db1, []HistoryVal{{34, "123"}}, false, []int{1}},
+		{db1, []HistoryVal{{45, "123"}}, false, []int{1}},
 
 		// Different values in same time
-		{"test2.db", []HistoryVal{{"abc", "123"}, {"def", "123"}}, false, []int{1, 1}},
+		{"test2.db", []HistoryVal{{34, "123"}, {45, "123"}}, false, []int{1, 1}},
 
 		// Duplicate Test
-		{"test3.db", []HistoryVal{{"abc", "123"}, {"abc", "123"}}, false, []int{1, 1}},
-		{"test3.db", []HistoryVal{{"abc", "123"}, {"abc", "456"}}, false, []int{1, 1}},
+		{"test3.db", []HistoryVal{{34, "123"}, {34, "123"}}, false, []int{1, 1}},
+		{"test3.db", []HistoryVal{{34, "123"}, {34, "456"}}, false, []int{1, 1}},
 
 		// Empty value
-		{"test4.db", []HistoryVal{{"abc", ""}}, false, []int{0}},
-		{"test5.db", []HistoryVal{{"", "123"}}, false, []int{1}},
+		{"test4.db", []HistoryVal{{34, ""}}, false, []int{0}},
 
 		// Empty string value
-		{"test6.db", []HistoryVal{{"abc", "123"}, {"abc", ""}}, false, []int{1, 0}},
+		{"test6.db", []HistoryVal{{34, "123"}, {34, ""}}, false, []int{1, 0}},
 
 		// Nil database
-		{"", []HistoryVal{{"abc", "123"}}, true, []int{1}},
+		{"", []HistoryVal{{34, "123"}}, true, []int{1}},
 	}
 
 	// Start testing

--- a/internal/history/struct.go
+++ b/internal/history/struct.go
@@ -5,6 +5,6 @@ package history
 //
 // This type is designed for insert value with different category at a time.
 type HistoryVal struct {
-	Category string // category to be inserted
-	Value    string // value to be inserted
+	Category categoryType // category to be inserted
+	Value    string       // value to be inserted
 }


### PR DESCRIPTION
Fix SQL in `history` module still using old string implementation, e.g. "Genre" but not 1.

### Checklist:

#### Code Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have run the new code for given condition and ensure the bugs is not appear again
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request

#### Documentation Checklist:

-   [x] I have modify file description to README.md of the package (if any)

#### Testing Checklist:

-   [x] I have create new test case for reproduce this bug
-   [x] I have run all new test case and pass locally with my changes
-   [x] I have run all existing test and pass locally with my changes
