### PR TITLE
Use default export folder in quick export

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,19 @@ After preview & press button to export, User can defined export folder, and expo
 
 Ignore preview section and generate `.cbz` with `komga` folder structure directly.
 
-Already contains a `.cbz` archive and `ComicInfo.xml` at `{selected-folder}/{comic-title}` location, while export location can NOT be changed.
+Default export location is inside selected folder. Export location can be changed by configuration ONLY.
 
-User can directly copy exported folder to `komga` comic directory.
+The file structure will be:
+
+```
+{export-folder OR selected folder}/
+├─ {comic-title}/
+│  ├─ {comic-title}.cbz
+│  │  ├─ {...images file}
+│  │  ├─ ComicInfo.xml
+```
+
+User can directly copy `{comic-title}/` folder to `komga` comic directory.
 
 ## Configuration
 

--- a/frontend/src/pages/helpPanel.tsx
+++ b/frontend/src/pages/helpPanel.tsx
@@ -56,13 +56,13 @@ export default function HelpPanel({ backToHome }: Readonly<HelpPanelProps>) {
 						<>
 							<p>Directly Export .cbz file with ComicInfo.xml inside. The generated file with be like:</p>
 							<p>
-								{" 📦 <Manga Name>\n" +
+								{" 📦 <Manga Name> OR <Default Export Directory>\n" +
 									" ┣ 📦 <Manga Name>  <-- Copy This Folder into Komga Comic Library\n" +
 									" ┃  ┣  📜<Manga Name>.cbz    <--- Generated .cbz\n" +
-									" ┣ 📜01.jpg\n" +
-									" ┣ 📜02.jpg\n" +
-									" ┣ <other images>\n" +
-									" ┗ 📜ComicInfo.xml\n"}
+									" ┃  ┃  ┣ 📜01.jpg\n" +
+									" ┃  ┃  ┣ 📜02.jpg\n" +
+									" ┃  ┃  ┣  <other images>\n" +
+									" ┗  ┗  ┗ 📜ComicInfo.xml\n"}
 							</p>
 						</>
 					}

--- a/internal/application/export.go
+++ b/internal/application/export.go
@@ -18,6 +18,7 @@ const comicInfoFile = "ComicInfo.xml"
 
 // Perform Quick Export Action,
 // where ComicInfo.xml file can not be modified before archived.
+// The input directory MUST be absolute path.
 //
 // If error is occur, then return a string containing the error message.
 // Otherwise, return empty string.
@@ -28,15 +29,13 @@ const comicInfoFile = "ComicInfo.xml"
 //  3. Wrap the .cbz file with a folder to copy to komga
 //
 // This function is specific designed for komga folder structure.
-func (a *App) QuickExportKomga(folder string) string {
-	absPath := folder
-
-	if absPath == "" {
+func (a *App) QuickExportKomga(inputDir string) string {
+	if inputDir == "" {
 		return "folder cannot be empty"
 	}
 
 	// Validate the directory
-	isValid, err := scanner.CheckFolder(absPath, scanner.ScanOpt{SubFolder: scanner.Reject, Image: scanner.Allow})
+	isValid, err := scanner.CheckFolder(inputDir, scanner.ScanOpt{SubFolder: scanner.Reject, Image: scanner.Allow})
 	if err != nil {
 		return err.Error()
 	} else if !isValid {
@@ -44,20 +43,20 @@ func (a *App) QuickExportKomga(folder string) string {
 	}
 
 	// Load Abs Path
-	c, err := scanner.ScanBooks(absPath)
+	c, err := scanner.ScanBooks(inputDir)
 	if err != nil {
 		return err.Error()
 	}
 
 	// Write ComicInfo.xml
-	err = comicinfo.Save(c, filepath.Join(absPath, comicInfoFile))
+	err = comicinfo.Save(c, filepath.Join(inputDir, comicInfoFile))
 	if err != nil {
 		fmt.Printf("error when saving: %v\n", err)
 		return err.Error()
 	}
 
 	// Start Archive
-	filename, _ := archive.CreateZip(absPath)
+	filename, _ := archive.CreateZip(inputDir)
 	err = archive.RenameZip(filename, true)
 	if err != nil {
 		fmt.Printf("error when archive: %v\n", err)

--- a/internal/application/export.go
+++ b/internal/application/export.go
@@ -56,7 +56,7 @@ func (a *App) QuickExportKomga(inputDir string) string {
 	}
 
 	// Start Archive
-	filename, _ := archive.CreateZip(inputDir)
+	filename, _ := archive.CreateZipTo(inputDir, inputDir)
 	err = archive.RenameZip(filename, true)
 	if err != nil {
 		fmt.Printf("error when archive: %v\n", err)

--- a/internal/application/export.go
+++ b/internal/application/export.go
@@ -55,8 +55,11 @@ func (a *App) QuickExportKomga(inputDir string) string {
 		return err.Error()
 	}
 
+	// Get destination folder
+	destDir := a.GetDefaultOutputDirectory(inputDir)
+
 	// Start Archive
-	filename, _ := archive.CreateZipTo(inputDir, inputDir)
+	filename, _ := archive.CreateZipTo(inputDir, destDir)
 	err = archive.RenameZip(filename, true)
 	if err != nil {
 		fmt.Printf("error when archive: %v\n", err)

--- a/internal/archive/zip.go
+++ b/internal/archive/zip.go
@@ -9,11 +9,6 @@ import (
 	"github.com/dark-person/comicinfo-parser/internal/files"
 )
 
-// Create ZIP File inside folderToAdd.
-func CreateZip(folderToAdd string) (dest string, err error) {
-	return CreateZipTo(folderToAdd, folderToAdd)
-}
-
 // Create ZIP File of inputDir, and output the zip to destDir.
 //
 // This function is a variant of CreateZip(), purpose to provide flexibility.

--- a/internal/archive/zip_test.go
+++ b/internal/archive/zip_test.go
@@ -14,67 +14,6 @@ const (
 	_xmlFile  = "test.xml"
 )
 
-// Test Create Zip from folder
-func TestCreateZip(t *testing.T) {
-	// Create a temp directory
-	tempDir := t.TempDir()
-
-	// Create a set of file
-	file1, _ := os.Create(filepath.Join(tempDir, _img1File))
-	file2, _ := os.Create(filepath.Join(tempDir, _img2File))
-	file3, _ := os.Create(filepath.Join(tempDir, _img3File))
-	file4, _ := os.Create(filepath.Join(tempDir, _xmlFile))
-	defer file1.Close()
-	defer file2.Close()
-	defer file3.Close()
-	defer file4.Close()
-
-	// Start Testing Functions
-	dest, err := CreateZip(tempDir)
-	if err != nil {
-		t.Error(err)
-	}
-
-	// Check Dest Filename
-	destFileName := filepath.Base(tempDir)
-	if dest != filepath.Join(tempDir, destFileName+".zip") {
-		t.Errorf("Error Destination file: %v", dest)
-	}
-
-	// Check Zip Content
-	reader, err := zip.OpenReader(dest)
-	if err != nil {
-		t.Error(err)
-	}
-	defer reader.Close()
-
-	list := make(map[string]int, 0)
-	for _, f := range reader.File {
-		list[f.Name] = 1
-	}
-
-	_, exist1 := list[_xmlFile]
-	_, exist2 := list[_img1File]
-	_, exist3 := list[_img2File]
-	_, exist4 := list[_img3File]
-
-	if !exist1 {
-		t.Error("Content 1 missing in zip")
-	}
-
-	if !exist2 {
-		t.Error("Content 2 missing in zip")
-	}
-
-	if !exist3 {
-		t.Error("Content 3 missing in zip")
-	}
-
-	if !exist4 {
-		t.Error("Content 4 missing in zip")
-	}
-}
-
 // Test Create Zip to destination from input folder.
 func TestCreateZipTo(t *testing.T) {
 	// Create a temp directory


### PR DESCRIPTION
### Changes 

- Use export default folder in config, instead of inside input folder
- Remove `CreateZip()` due to no usage
- Adjust variable naming

### Related Issues

This request will complete solve issue #58. 

Close #58.

### Checklist:

#### Code Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request

#### Documentation Checklist:

-   [x] I have add new feature description to README.md of this repository
-   [x] I have add/modify file description to README.md of the package (tick if not applicable)

#### Testing Checklist:

-   [x] I have create new test case / test for new feature
-   [x] I have run all new & existing test and pass locally with my changes
