### PR TITLE
Make folder select UI as separate component

### DIFF
--- a/frontend/src/components/FolderSelector.tsx
+++ b/frontend/src/components/FolderSelector.tsx
@@ -1,0 +1,70 @@
+import Button from "react-bootstrap/Button";
+import Form from "react-bootstrap/Form";
+import InputGroup from "react-bootstrap/InputGroup";
+
+import { GetDirectory, GetDirectoryWithDefault } from "../../wailsjs/go/application/App";
+
+type FolderSelectorProps = {
+	/** ID of root element. */
+	id?: string;
+	/** Class name for root element. */
+	className?: string;
+
+	/** Text act as label for this folder selector element. */
+	label?: string;
+	/** Absoulte path of selected directory. */
+	directory: string;
+	/** React state hook setter for selected directory. */
+	setDirectory: (value: string) => void;
+
+	/** ID of readonly input element, that display selected directory. */
+	inputId?: string;
+	/** Class name for readonly input element, that display selected directory.*/
+	inputClassName?: string;
+
+	/** Id of button that open dialog to select path. */
+	buttonId?: string;
+	/** Class name of button that open dialog to select path. */
+	buttonClassName?: string;
+	/** Button variant. */
+	buttonVariant?: string;
+};
+
+/** UI component for select folder. */
+export default function FolderSelector(props: Readonly<FolderSelectorProps>) {
+	/** Handler for click "Select Folder". This will open file chooser for choose a file. */
+	function handleSelect() {
+		if (props.directory !== "") {
+			GetDirectoryWithDefault(props.directory).then((input) => {
+				props.setDirectory(input);
+			});
+		} else {
+			GetDirectory().then((input) => {
+				props.setDirectory(input);
+			});
+		}
+	}
+
+	return (
+		<InputGroup id={props.id} className={props.className ?? "my-2"}>
+			{props.label !== undefined && <InputGroup.Text>{props.label}</InputGroup.Text>}
+
+			<Form.Control
+				id={props.inputId}
+				className={props.inputClassName}
+				type="text"
+				placeholder="select folder.."
+				value={props.directory}
+				readOnly
+			/>
+
+			<Button
+				id={props.buttonId}
+				className={props.buttonClassName}
+				variant={props.buttonVariant ?? "secondary"}
+				onClick={handleSelect}>
+				Select Folder
+			</Button>
+		</InputGroup>
+	);
+}

--- a/frontend/src/pages/exportPanel.tsx
+++ b/frontend/src/pages/exportPanel.tsx
@@ -3,19 +3,13 @@ import { useEffect, useState } from "react";
 
 // React Component
 import Button from "react-bootstrap/Button";
-import Form from "react-bootstrap/Form";
-import InputGroup from "react-bootstrap/InputGroup";
 
 // Project Component
+import FolderSelector from "../components/FolderSelector";
 import { ModalControl } from "../controls/ModalControl";
 
 // Wails
-import {
-	ExportCbz,
-	GetDefaultOutputDirectory,
-	GetDirectory,
-	GetDirectoryWithDefault,
-} from "../../wailsjs/go/application/App";
+import { ExportCbz, GetDefaultOutputDirectory } from "../../wailsjs/go/application/App";
 import { comicinfo } from "../../wailsjs/go/models";
 
 /** Props Interface for FolderSelect */
@@ -45,19 +39,6 @@ export default function ExportPanel({ comicInfo: info, originalDirectory, modalC
 			});
 		}
 	}, []);
-
-	/** Handler for click "Select Folder". This will open file chooser for choose a file. */
-	function handleSelect() {
-		if (exportDir !== "") {
-			GetDirectoryWithDefault(exportDir).then((input) => {
-				setExportDir(input);
-			});
-		} else {
-			GetDirectory().then((input) => {
-				setExportDir(input);
-			});
-		}
-	}
 
 	/**
 	 * Handler for click export .cbz only, export path will be the folder chosen by file chooser.
@@ -95,19 +76,12 @@ export default function ExportPanel({ comicInfo: info, originalDirectory, modalC
 			<h5 className="mb-4">Export to .cbz</h5>
 
 			{/* File Chooser */}
-			<InputGroup className="mb-3">
-				<InputGroup.Text>Export Folder</InputGroup.Text>
-				<Form.Control
-					aria-describedby="btn-select-export-folder"
-					type="text"
-					placeholder="select folder.."
-					value={exportDir}
-					readOnly
-				/>
-				<Button variant="secondary" id="btn-select-export-folder" onClick={handleSelect}>
-					Select Folder
-				</Button>
-			</InputGroup>
+			<FolderSelector
+				className={"mb-3"}
+				label={"Export Folder"}
+				directory={exportDir}
+				setDirectory={setExportDir}
+			/>
 
 			{/* Button to Export. Use d-grid to create block button, use w-25 to smaller size. */}
 			<div className="w-25 mx-auto d-grid gap-2">

--- a/frontend/src/pages/folderSelect.tsx
+++ b/frontend/src/pages/folderSelect.tsx
@@ -3,14 +3,13 @@ import { useState } from "react";
 
 // Component
 import Button from "react-bootstrap/Button";
-import Form from "react-bootstrap/Form";
-import InputGroup from "react-bootstrap/InputGroup";
 
 // Project Specific Component
+import FolderSelector from "../components/FolderSelector";
 import { ModalControl } from "../controls/ModalControl";
 
 // Wails
-import { GetDirectory, GetDirectoryWithDefault, QuickExportKomga } from "../../wailsjs/go/application/App";
+import { QuickExportKomga } from "../../wailsjs/go/application/App";
 
 /** Props Interface for FolderSelect */
 type FolderProps = {
@@ -28,19 +27,6 @@ type FolderProps = {
 export default function FolderSelect({ handleFolder, showHelpPanel, modalControl }: Readonly<FolderProps>) {
 	/** The Directory Absolute Path selected by User. */
 	const [directory, setDirectory] = useState("");
-
-	/** Handler when user clicked select folder. It will use different function depend on there are already selected folder or not */
-	function handleSelect() {
-		if (directory !== "") {
-			GetDirectoryWithDefault(directory).then((input) => {
-				setDirectory(input);
-			});
-		} else {
-			GetDirectory().then((input) => {
-				setDirectory(input);
-			});
-		}
-	}
 
 	/** Handler when user clicked Quick Export Komga Button. Start quick export process. */
 	function handleQuickExport() {
@@ -66,19 +52,13 @@ export default function FolderSelect({ handleFolder, showHelpPanel, modalControl
 			<h5 className="mb-4">Select Folder to Start:</h5>
 
 			{/* Folder Chooser */}
-			<InputGroup className="mb-3">
-				<InputGroup.Text>Image Folder</InputGroup.Text>
-				<Form.Control
-					aria-describedby="btn-select-folder"
-					type="text"
-					placeholder="select folder.."
-					value={directory}
-					readOnly
-				/>
-				<Button variant="secondary" id="btn-select-folder" onClick={handleSelect}>
-					Select Folder
-				</Button>
-			</InputGroup>
+			<FolderSelector
+				className="mb-3"
+				label="Image Folder"
+				buttonId="btn-select-folder"
+				directory={directory}
+				setDirectory={setDirectory}
+			/>
 
 			{/* Button Group */}
 			<div className="w-25 mx-auto d-grid gap-2">


### PR DESCRIPTION
### Changes Made

- Add UI component folder selector (from original folder select input group)
- Change export panel & folder select panel to use new component

### Reason of Changes

Provide UI component for future custom wrap folder.

### Checklist:

-   [ ] I have run the new code and ensure the change is work expected
-   [ ] I have write/modify comments to important function & hard-to-understand code
-   [ ] I have create/modify corresponding test for new changes
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have run all new & existing test and pass locally with my changes
-   [ ] I have checked my code has no misspellings & no warnings
-   [ ] I have checked that only essential code remains in this pull request
