### PR TITLE
Improve yaml config: key naming & test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ You may found a sample of configuration file in `config-example.yaml`, and defau
 
 You should use absolute paths as possible. If folder is missing, then program will try to create for all folders.
 
-| Field            | Type   | Usage                                                                           |
-| ---------------- | ------ | ------------------------------------------------------------------------------- |
-| `default`        | struct | storing default values for program                                              |
-| `default.export` | string | default export folder path, if empty string, then create inside input directory |
+| Field                   | Type   | Usage                                                                           |
+| ----------------------- | ------ | ------------------------------------------------------------------------------- |
+| `default`               | struct | storing default values for program                                              |
+| `default.export-folder` | string | default export folder path, if empty string, then create inside input directory |
 
 ## Data
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ your-folder/
 
 If no configuration is found, program will NOT create for yourself. Instead, it will use its default behavior.
 
-You may found a sample of configuration file in `config-example.yaml`.
+You may found a sample of configuration file in `config-example.yaml`, and default values in `config-default.yaml`.
 
 ### Configuration Options
 

--- a/config-default.yaml
+++ b/config-default.yaml
@@ -1,0 +1,2 @@
+default:
+    export: 

--- a/config-default.yaml
+++ b/config-default.yaml
@@ -1,2 +1,2 @@
 default:
-    export: 
+    export-folder:

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1,2 +1,2 @@
 default:
-    export: ./my-export
+    export-folder: ./my-export

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1,5 +1,2 @@
 default:
     export: ./my-export
-export:
-    - ./folder1
-    - ./folder2

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -25,6 +25,7 @@ func TestLoadYaml(t *testing.T) {
 		{"mock/case-normal.yaml", &ProgramConfig{DefaultExport: filepath.Join(exPath, "./my-export")}, false},
 		{"mock/case-typo1.yaml", &ProgramConfig{DefaultExport: ""}, false},
 		{"mock/case-typo2.yaml", &ProgramConfig{DefaultExport: ""}, false},
+		{"mock/case-empty.yaml", &ProgramConfig{DefaultExport: ""}, false},
 		{"mock/not-exist.yaml", nil, true},
 	}
 

--- a/internal/config/mock/case-empty.yaml
+++ b/internal/config/mock/case-empty.yaml
@@ -1,0 +1,2 @@
+default:
+    export-folder:

--- a/internal/config/mock/case-normal.yaml
+++ b/internal/config/mock/case-normal.yaml
@@ -1,2 +1,2 @@
 default:
-    export: ./my-export
+    export-folder: ./my-export

--- a/internal/config/mock/case-typo1.yaml
+++ b/internal/config/mock/case-typo1.yaml
@@ -1,2 +1,2 @@
 defaults:
-    export: ./my-export
+    export-folder: ./my-export

--- a/internal/config/mock/case-typo2.yaml
+++ b/internal/config/mock/case-typo2.yaml
@@ -1,2 +1,2 @@
 default:
-    exports: ./my-export
+    exports-folder: ./my-export

--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -4,7 +4,7 @@ package config
 
 // Config for this program.
 type ProgramConfig struct {
-	DefaultExport string `koanf:"default.export"` // Default export folder, apply to both quick & standard
+	DefaultExport string `koanf:"default.export-folder"` // Default export folder, apply to both quick & standard
 }
 
 // Default config struct for this program.


### PR DESCRIPTION
### Changes Made

- Rename `default.export` key to `default.export-folder` for readability.
- Add empty `config.yaml` in test case.

### Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have create/modify corresponding test for new changes
-   [x] I have made corresponding changes to the documentation
-   [x] I have run all new & existing test and pass locally with my changes
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request
