### PR TITLE
Fix folder already exist block export during create folder

### DIFF
--- a/internal/archive/rename.go
+++ b/internal/archive/rename.go
@@ -76,7 +76,7 @@ func RenameZip(absPath string, opt RenameOption) error {
 	}
 
 	err := os.Mkdir(wrappedDir, 0755)
-	if err != nil {
+	if err != nil && !os.IsExist(err) { // Folder already exist is not an error
 		return err
 	}
 

--- a/internal/archive/rename_test.go
+++ b/internal/archive/rename_test.go
@@ -38,6 +38,28 @@ func TestRenameZipCustomWrap(t *testing.T) {
 		t.Error(openErr)
 	}
 	defer dest.Close()
+
+	// ========= Test again with another zip file but same path =========
+
+	// Prepare zip path
+	zipPath2 := filepath.Join(tempDir, "tmp", "hello2.zip")
+
+	// Create a zip file
+	file2, _ := os.Create(zipPath2)
+	file2.Close()
+
+	// Test Function
+	err = RenameZip(zipPath2, UseCustomWrap("abc"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Result Verify
+	dest2, openErr := os.Open(filepath.Join(tempDir, "tmp", "abc", "hello2.cbz"))
+	if openErr != nil {
+		t.Error(openErr)
+	}
+	defer dest2.Close()
 }
 
 // Test Rename Zip archive to .cbz archive, with default wrap option is enabled.


### PR DESCRIPTION
This is not an error since folder exist or not, should not affect cbz export function

### Related Issues

N/A.

### Bug Cause & Solution

When call export function, `os.Mkdir` will be called to ensure folder is exist.

However, if folder is already exist, then export function will failed.

A checking to `os.Mkdir` error will be performed.

### Notes (If any)

This bug is due to custom wrap folder function.

### Checklist:

#### Code Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have run the new code for given condition and ensure the bugs is not appear again
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request

#### Documentation Checklist:

-   [x] I have modify file description to README.md of the package (if any)

#### Testing Checklist:

-   [x] I have create new test case for reproduce this bug
-   [x] I have run all new test case and pass locally with my changes
-   [x] I have run all existing test and pass locally with my changes
