### PR TITLE
Rewrite wails directory dialog & folder selector

### DIFF
--- a/frontend/src/components/FolderSelector.tsx
+++ b/frontend/src/components/FolderSelector.tsx
@@ -16,6 +16,8 @@ type FolderSelectorProps = {
 	directory: string;
 	/** React state hook setter for selected directory. */
 	setDirectory: (value: string) => void;
+	/** Default directory to open if no directory selected. */
+	defaultDirectory?: string;
 
 	/** ID of readonly input element, that display selected directory. */
 	inputId?: string;
@@ -34,12 +36,26 @@ type FolderSelectorProps = {
 export default function FolderSelector(props: Readonly<FolderSelectorProps>) {
 	/** Handler for click "Select Folder". This will open file chooser for choose a file. */
 	function handleSelect() {
-		GetDirectory(props.directory).then((resp) => {
+		let dir = props.directory;
+
+		// Use default directory if no directory selected.
+		if (dir === "" && props.defaultDirectory !== undefined) {
+			dir = props.defaultDirectory;
+		}
+
+		GetDirectory(dir).then((resp) => {
 			if (resp.ErrMsg !== "") {
 				console.error(resp.ErrMsg);
 			}
 
-			props.setDirectory(resp.SelectedDir);
+			let dirToUse = resp.SelectedDir;
+
+			// When user failed to select/cancel, enfore to use default directory if any
+			if (dirToUse === "" && props.defaultDirectory !== undefined) {
+				dirToUse = props.defaultDirectory;
+			}
+
+			props.setDirectory(dirToUse);
 		});
 	}
 

--- a/frontend/src/components/FolderSelector.tsx
+++ b/frontend/src/components/FolderSelector.tsx
@@ -2,7 +2,7 @@ import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import InputGroup from "react-bootstrap/InputGroup";
 
-import { GetDirectory, GetDirectoryWithDefault } from "../../wailsjs/go/application/App";
+import { GetDirectory } from "../../wailsjs/go/application/App";
 
 type FolderSelectorProps = {
 	/** ID of root element. */
@@ -34,15 +34,13 @@ type FolderSelectorProps = {
 export default function FolderSelector(props: Readonly<FolderSelectorProps>) {
 	/** Handler for click "Select Folder". This will open file chooser for choose a file. */
 	function handleSelect() {
-		if (props.directory !== "") {
-			GetDirectoryWithDefault(props.directory).then((input) => {
-				props.setDirectory(input);
-			});
-		} else {
-			GetDirectory().then((input) => {
-				props.setDirectory(input);
-			});
-		}
+		GetDirectory(props.directory).then((resp) => {
+			if (resp.ErrMsg !== "") {
+				console.error(resp.ErrMsg);
+			}
+
+			props.setDirectory(resp.SelectedDir);
+		});
 	}
 
 	return (

--- a/frontend/src/pages/exportPanel.tsx
+++ b/frontend/src/pages/exportPanel.tsx
@@ -49,6 +49,7 @@ export default function ExportPanel({
 	setExportMethod,
 }: Readonly<ExportProps>) {
 	// Since this is the final step, could ignore the interaction with App.tsx
+	const [defaultDir, setDefaultDir] = useState<string>("");
 	const [exportDir, setExportDir] = useState<string>("");
 	const [customWrap, setCustomWrap] = useState<string>("");
 
@@ -57,6 +58,7 @@ export default function ExportPanel({
 		if (originalDirectory !== undefined) {
 			// Load config from file
 			GetDefaultOutputDirectory(originalDirectory).then((dir) => {
+				setDefaultDir(dir);
 				setExportDir(dir);
 			});
 
@@ -132,6 +134,7 @@ export default function ExportPanel({
 				label={"Export Folder"}
 				directory={exportDir}
 				setDirectory={setExportDir}
+				defaultDirectory={defaultDir}
 			/>
 
 			{/* Radio Buttons */}

--- a/frontend/wailsjs/go/application/App.d.ts
+++ b/frontend/wailsjs/go/application/App.d.ts
@@ -21,9 +21,7 @@ export function GetComicInfo(arg1:string):Promise<application.ComicInfoResponse>
 
 export function GetDefaultOutputDirectory(arg1:string):Promise<string>;
 
-export function GetDirectory():Promise<string>;
-
-export function GetDirectoryWithDefault(arg1:string):Promise<string>;
+export function GetDirectory(arg1:string):Promise<application.DirectoryResp>;
 
 export function OpenFolder(arg1:string):Promise<void>;
 

--- a/frontend/wailsjs/go/application/App.js
+++ b/frontend/wailsjs/go/application/App.js
@@ -38,12 +38,8 @@ export function GetDefaultOutputDirectory(arg1) {
   return window['go']['application']['App']['GetDefaultOutputDirectory'](arg1);
 }
 
-export function GetDirectory() {
-  return window['go']['application']['App']['GetDirectory']();
-}
-
-export function GetDirectoryWithDefault(arg1) {
-  return window['go']['application']['App']['GetDirectoryWithDefault'](arg1);
+export function GetDirectory(arg1) {
+  return window['go']['application']['App']['GetDirectory'](arg1);
 }
 
 export function OpenFolder(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -32,6 +32,20 @@ export namespace application {
 		    return a;
 		}
 	}
+	export class DirectoryResp {
+	    SelectedDir: string;
+	    ErrMsg: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new DirectoryResp(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.SelectedDir = source["SelectedDir"];
+	        this.ErrMsg = source["ErrMsg"];
+	    }
+	}
 	export class HistoryResp {
 	    Inputs: string[];
 	    ErrorMsg: string;

--- a/internal/application/directory.go
+++ b/internal/application/directory.go
@@ -1,44 +1,39 @@
 package application
 
 import (
-	"path/filepath"
-
-	"github.com/sirupsen/logrus"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
-// Open a Dialog for user to select Directory.
-//
-// If Error is occur, then this function will return an empty string
-func (a *App) GetDirectory() string {
-	directory, err := runtime.OpenDirectoryDialog(a.ctx, runtime.OpenDialogOptions{
-		Title: "Select Directory",
-	})
-
-	if err != nil {
-		logrus.Warnf("Error when getting directory from user: %v\n", err)
-		return ""
-	}
-	return directory
+// Response for get directory method. Designed due to wails API only allow single return.
+type DirectoryResp struct {
+	SelectedDir string
+	ErrMsg      string
 }
 
-// Open a Dialog for user to select Directory, this dialog will show default directory when open.
+// Open directory dialog for wails, allow user to select one directory.
 //
-// If Error is occur, then this function will return an empty string
-func (a *App) GetDirectoryWithDefault(defaultDirectory string) string {
-	// Try to get parent of default directory
-	dir := filepath.Dir(defaultDirectory)
+// If given directory is empty, then default directory will be handled by wails.
+// Otherwise, it will open given directory.
+//
+// If any error occur, the error message will be also returned in 2nd argument.
+// Empty string indicate no error occur.
+func (a *App) GetDirectory(dir string) DirectoryResp {
+	const title = "Select Directory"
 
-	directory, err := runtime.OpenDirectoryDialog(a.ctx, runtime.OpenDialogOptions{
-		Title:            "Select Directory",
-		DefaultDirectory: dir,
-	})
+	var opt runtime.OpenDialogOptions
 
-	if err != nil {
-		logrus.Warnf("Error when getting directory from user: %v\n", err)
-		return ""
+	if dir == "" {
+		opt = runtime.OpenDialogOptions{Title: title}
+	} else {
+		opt = runtime.OpenDialogOptions{Title: title, DefaultDirectory: dir}
 	}
-	return directory
+
+	directory, err := runtime.OpenDirectoryDialog(a.ctx, opt)
+	if err != nil {
+		return DirectoryResp{SelectedDir: "", ErrMsg: err.Error()}
+	}
+
+	return DirectoryResp{SelectedDir: directory, ErrMsg: ""}
 }
 
 // Attempt to load default output directory.


### PR DESCRIPTION
### Changes Made

Rewrite wails directory dialog API to simpler implementation.

### Reason of Changes

1. The original API may be complex and not flexible
2. Default directory behaviour confused due to it open parent folder instead of given directory.

### Checklist:

-   [ ] I have run the new code and ensure the change is work expected
-   [ ] I have write/modify comments to important function & hard-to-understand code
-   [ ] I have create/modify corresponding test for new changes
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have run all new & existing test and pass locally with my changes
-   [ ] I have checked my code has no misspellings & no warnings
-   [ ] I have checked that only essential code remains in this pull request
