### PR TITLE
Customize default directory of dialog when select comic folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You should use absolute paths as possible. If folder is missing, then program wi
 | ----------------------- | ------ | ------------------------------------------------------------------------------- |
 | `default`               | struct | storing default values for program                                              |
 | `default.export-folder` | string | default export folder path, if empty string, then create inside input directory |
+| `default.comic-folder`  | string | default folder location when choose folder to create comicinfo                  |
 
 ## Data
 

--- a/config-default.yaml
+++ b/config-default.yaml
@@ -1,2 +1,3 @@
 default:
     export-folder:
+    comic-folder:

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1,2 +1,3 @@
 default:
     export-folder: ./my-export
+    comic-folder: ./my-input

--- a/frontend/src/pages/folderSelect.tsx
+++ b/frontend/src/pages/folderSelect.tsx
@@ -1,5 +1,5 @@
 // React
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 // Component
 import Button from "react-bootstrap/Button";
@@ -9,7 +9,7 @@ import FolderSelector from "../components/FolderSelector";
 import { ModalControl } from "../controls/ModalControl";
 
 // Wails
-import { QuickExportKomga } from "../../wailsjs/go/application/App";
+import { GetComicFolder, QuickExportKomga } from "../../wailsjs/go/application/App";
 
 /** Props Interface for FolderSelect */
 type FolderProps = {
@@ -27,6 +27,13 @@ type FolderProps = {
 export default function FolderSelect({ handleFolder, showHelpPanel, modalControl }: Readonly<FolderProps>) {
 	/** The Directory Absolute Path selected by User. */
 	const [directory, setDirectory] = useState("");
+
+	/** Default directory for comic folder. */
+	const [comicFolder, setComicFolder] = useState<string | undefined>(undefined);
+
+	useEffect(() => {
+		GetComicFolder().then((dir) => setComicFolder(dir));
+	}, []);
 
 	/** Handler when user clicked Quick Export Komga Button. Start quick export process. */
 	function handleQuickExport() {
@@ -58,6 +65,7 @@ export default function FolderSelect({ handleFolder, showHelpPanel, modalControl
 				buttonId="btn-select-folder"
 				directory={directory}
 				setDirectory={setDirectory}
+				defaultDirectory={comicFolder}
 			/>
 
 			{/* Button Group */}

--- a/frontend/wailsjs/go/application/App.d.ts
+++ b/frontend/wailsjs/go/application/App.d.ts
@@ -17,6 +17,8 @@ export function GetAllPublisherInput():Promise<application.HistoryResp>;
 
 export function GetAllTagInput():Promise<application.HistoryResp>;
 
+export function GetComicFolder():Promise<string>;
+
 export function GetComicInfo(arg1:string):Promise<application.ComicInfoResponse>;
 
 export function GetDefaultOutputDirectory(arg1:string):Promise<string>;

--- a/frontend/wailsjs/go/application/App.js
+++ b/frontend/wailsjs/go/application/App.js
@@ -30,6 +30,10 @@ export function GetAllTagInput() {
   return window['go']['application']['App']['GetAllTagInput']();
 }
 
+export function GetComicFolder() {
+  return window['go']['application']['App']['GetComicFolder']();
+}
+
 export function GetComicInfo(arg1) {
   return window['go']['application']['App']['GetComicInfo'](arg1);
 }

--- a/internal/application/directory.go
+++ b/internal/application/directory.go
@@ -45,3 +45,13 @@ func (a *App) GetDefaultOutputDirectory(inputDir string) string {
 
 	return a.cfg.DefaultExport
 }
+
+// Attempt to load default comic folder.
+// If config is not set, then return a empty string instead.
+func (a *App) GetComicFolder() string {
+	if a.cfg == nil {
+		return ""
+	}
+
+	return a.cfg.DefaultComicDir
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -41,6 +41,11 @@ func LoadYaml(path string) (*ProgramConfig, error) {
 		return Default(), err
 	}
 
+	out.DefaultComicDir, err = parsePath(out.DefaultComicDir)
+	if err != nil {
+		return Default(), err
+	}
+
 	return &out, nil
 }
 

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -22,10 +22,10 @@ func TestLoadYaml(t *testing.T) {
 	t.Log(exPath)
 
 	tests := []testCase{
-		{"mock/case-normal.yaml", &ProgramConfig{DefaultExport: filepath.Join(exPath, "./my-export")}, false},
-		{"mock/case-typo1.yaml", &ProgramConfig{DefaultExport: ""}, false},
-		{"mock/case-typo2.yaml", &ProgramConfig{DefaultExport: ""}, false},
-		{"mock/case-empty.yaml", &ProgramConfig{DefaultExport: ""}, false},
+		{"mock/case-normal.yaml", &ProgramConfig{DefaultExport: filepath.Join(exPath, "./my-export"), DefaultComicDir: filepath.Join(exPath, "./my-input")}, false},
+		{"mock/case-typo1.yaml", &ProgramConfig{DefaultExport: "", DefaultComicDir: ""}, false},
+		{"mock/case-typo2.yaml", &ProgramConfig{DefaultExport: "", DefaultComicDir: ""}, false},
+		{"mock/case-empty.yaml", &ProgramConfig{DefaultExport: "", DefaultComicDir: ""}, false},
 		{"mock/not-exist.yaml", nil, true},
 	}
 

--- a/internal/config/mock/case-empty.yaml
+++ b/internal/config/mock/case-empty.yaml
@@ -1,2 +1,3 @@
 default:
     export-folder:
+    comic-folder:

--- a/internal/config/mock/case-normal.yaml
+++ b/internal/config/mock/case-normal.yaml
@@ -1,2 +1,3 @@
 default:
     export-folder: ./my-export
+    comic-folder: ./my-input

--- a/internal/config/mock/case-typo1.yaml
+++ b/internal/config/mock/case-typo1.yaml
@@ -1,2 +1,3 @@
 defaults:
     export-folder: ./my-export
+    comic-folder: ./my-input

--- a/internal/config/mock/case-typo2.yaml
+++ b/internal/config/mock/case-typo2.yaml
@@ -1,2 +1,3 @@
 default:
     exports-folder: ./my-export
+    comics-folder: ./my-input

--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -4,12 +4,14 @@ package config
 
 // Config for this program.
 type ProgramConfig struct {
-	DefaultExport string `koanf:"default.export-folder"` // Default export folder, apply to both quick & standard
+	DefaultComicDir string `koanf:"default.comic-folder"`  // Default input directory, all folder select dialog will start from here
+	DefaultExport   string `koanf:"default.export-folder"` // Default export folder, apply to both quick & standard
 }
 
 // Default config struct for this program.
 func Default() *ProgramConfig {
 	return &ProgramConfig{
-		DefaultExport: "", // Indicate input folder is used
+		DefaultComicDir: "", // Indicate use wails default directory
+		DefaultExport:   "", // Indicate input folder is used
 	}
 }


### PR DESCRIPTION
### Changes (New Feature)

Allow user to customize default folder when select folder to create comicinfo.xml. The value is configured by `yaml`.

### Checklist:

#### Code Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request

#### Documentation Checklist:

-   [x] I have add new feature description to README.md of this repository
-   [x] I have add/modify file description to README.md of the package (tick if not applicable)

#### Testing Checklist:

-   [x] I have create new test case / test for new feature
-   [x] I have run all new & existing test and pass locally with my changes
