### PR TITLE
Fix folder that only contain `.webp` cannot generate comicinfo

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -15,7 +15,7 @@ import (
 func isSupportedImg(filename string) bool {
 	ext := filepath.Ext(filename)
 	ext = strings.ToLower(ext)
-	return ext == ".jpg" || ext == ".png" || ext == ".jpeg"
+	return ext == ".jpg" || ext == ".png" || ext == ".jpeg" || ext == ".webp"
 }
 
 // Scan all image in the Directory. Sorted by filename.

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -11,6 +11,13 @@ import (
 	"github.com/dark-person/comicinfo-parser/internal/parser"
 )
 
+// Check if image file extension is supported.
+func isSupportedImg(filename string) bool {
+	ext := filepath.Ext(filename)
+	ext = strings.ToLower(ext)
+	return ext == ".jpg" || ext == ".png" || ext == ".jpeg"
+}
+
 // Scan all image in the Directory. Sorted by filename.
 func GetPageInfo(absPath string) (pages []comicinfo.ComicPageInfo, err error) {
 	entries, err := os.ReadDir(absPath)
@@ -23,10 +30,7 @@ func GetPageInfo(absPath string) (pages []comicinfo.ComicPageInfo, err error) {
 	// Image must be re-scan due to image contents may changed
 	imageIdx := 0
 	for _, entry := range entries {
-		ext := filepath.Ext(entry.Name())
-		ext = strings.ToLower(ext)
-
-		if ext != ".jpg" && ext != ".png" && ext != ".jpeg" {
+		if !isSupportedImg(entry.Name()) {
 			continue
 		}
 
@@ -138,9 +142,7 @@ func CheckFolder(folderPath string, opt ScanOpt) (bool, error) {
 		}
 
 		// Image Extension check
-		ext := filepath.Ext(entry.Name())
-		ext = strings.ToLower(ext)
-		if ext == ".jpg" || ext == ".png" || ext == ".jpeg" {
+		if isSupportedImg(entry.Name()) {
 			imageCount++
 			continue
 		}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -238,9 +238,9 @@ func TestIsSupportedImg(t *testing.T) {
 		{"foo/image1.jpg", true},
 		{"foo/image2.png", true},
 		{"foo/image3.jpeg", true},
+		{"foo/image4.webp", true},
 
 		// Not Supported
-		{"foo/image4.webp", false},
 		{"foo/abc/", false},
 		{"foo/abc.txt", false},
 		{"foo/abc.docx", false},

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -227,3 +227,26 @@ func TestCheckFolder(t *testing.T) {
 	}
 
 }
+
+func TestIsSupportedImg(t *testing.T) {
+	type testCase struct {
+		filename string
+		want     bool
+	}
+
+	tests := []testCase{
+		{"foo/image1.jpg", true},
+		{"foo/image2.png", true},
+		{"foo/image3.jpeg", true},
+
+		// Not Supported
+		{"foo/image4.webp", false},
+		{"foo/abc/", false},
+		{"foo/abc.txt", false},
+		{"foo/abc.docx", false},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, isSupportedImg(tt.filename))
+	}
+}


### PR DESCRIPTION
### Bug Cause & Solution

Folder that contains only `.webp` image cannot be generate comicinfo, display folder structure not correct.

Add back `.webp` image support to function.

### Notes (If any)

Also tidy `scanner` package function on image extension check.

### Checklist:

#### Code Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have run the new code for given condition and ensure the bugs is not appear again
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request

#### Documentation Checklist:

-   [x] I have modify file description to README.md of the package (if any)

#### Testing Checklist:

-   [x] I have create new test case for reproduce this bug
-   [x] I have run all new test case and pass locally with my changes
-   [x] I have run all existing test and pass locally with my changes
