### PR TITLE
Fix unexpected error when custom wrap folder has trailing space

### DIFF
--- a/internal/archive/rename.go
+++ b/internal/archive/rename.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/dark-person/comicinfo-parser/internal/files"
 )
@@ -72,7 +73,7 @@ func RenameZip(absPath string, opt RenameOption) error {
 	if opt.isDefaultWrap {
 		wrappedDir = filepath.Join(originalDir, name)
 	} else {
-		wrappedDir = filepath.Join(originalDir, opt.customWrapFolder)
+		wrappedDir = filepath.Join(originalDir, strings.TrimSpace(opt.customWrapFolder))
 	}
 
 	err := os.Mkdir(wrappedDir, 0755)

--- a/internal/archive/rename_test.go
+++ b/internal/archive/rename_test.go
@@ -30,6 +30,10 @@ func TestRenameZip(t *testing.T) {
 		{"case1.zip", NoWrap(), "case1.cbz"},
 		{"case2.zip", UseDefaultWrap(), "case2/case2.cbz"},
 		{"case3.zip", UseCustomWrap("def"), "def/case3.cbz"},
+
+		// Check custom wrap with space
+		{"case4.zip", UseCustomWrap("ghi "), "ghi/case4.cbz"},
+		{"case5.zip", UseCustomWrap(" jkl"), "jkl/case5.cbz"},
 	}
 
 	for _, tt := range tests {

--- a/internal/archive/zip.go
+++ b/internal/archive/zip.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/dark-person/comicinfo-parser/internal/files"
 )
@@ -13,7 +14,12 @@ import (
 //
 // This function is a variant of CreateZip(), purpose to provide flexibility.
 func CreateZipTo(inputDir string, destDir string) (dest string, err error) {
-	destFileName := filepath.Base(inputDir)
+	// Prevent space include in paths
+	inputDir = strings.TrimSpace(inputDir)
+	destDir = strings.TrimSpace(destDir)
+
+	// Get destination zip filename
+	destFileName := strings.TrimSpace(filepath.Base(inputDir))
 
 	// Create temp directory
 	tmpDir, err := os.MkdirTemp("", "comicinfo-zip-*")
@@ -43,6 +49,11 @@ func CreateZipTo(inputDir string, destDir string) (dest string, err error) {
 // This function will return path of created zip file.
 // If any error occur, this function will return that error directly.
 func createArchive(inputDir, destDir, zipFilename string) (createdZip string, err error) {
+	// Ensure all input not contains spaces
+	inputDir = strings.TrimSpace(inputDir)
+	destDir = strings.TrimSpace(destDir)
+	zipFilename = strings.TrimSpace(zipFilename)
+
 	// Create ZIP File
 	f, err := os.Create(filepath.Join(destDir, zipFilename+".zip"))
 	if err != nil {

--- a/internal/archive/zip_test.go
+++ b/internal/archive/zip_test.go
@@ -48,6 +48,7 @@ func TestCreateZipTo(t *testing.T) {
 
 	tests := []testCase{
 		{"input1", "output1", "output1/input1.zip"},
+		{"input2 ", "output2", "output2/input2.zip"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### Bug Cause & Solution

When using custom wrap folder function, if folder name contains trailing space, the .cbz creation will be failed.

### Checklist:

#### Code Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have run the new code for given condition and ensure the bugs is not appear again
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request

#### Documentation Checklist:

-   [x] I have modify file description to README.md of the package (if any)

#### Testing Checklist:

-   [x] I have create new test case for reproduce this bug
-   [x] I have run all new test case and pass locally with my changes
-   [x] I have run all existing test and pass locally with my changes
