### PR TITLE
Add support to append item in comicinfo struct

### DIFF
--- a/internal/comicinfo/ComicInfo.go
+++ b/internal/comicinfo/ComicInfo.go
@@ -2,7 +2,6 @@ package comicinfo
 
 import (
 	"encoding/xml"
-	"strings"
 )
 
 // Schema Version of Current ComicInfo Structure
@@ -72,19 +71,7 @@ type ComicInfo struct {
 // Add Tags to the comic info container.
 // This function will handle the comma separation automatically.
 func (c *ComicInfo) AddTags(tags ...string) {
-	original := strings.Split(c.Tags, ",")
-	new := append(original, tags...)
-
-	temp := make([]string, 0)
-	for _, tag := range new {
-		// Prevent Empty Strings
-		if strings.TrimSpace(tag) == "" {
-			continue
-		}
-		temp = append(temp, tag)
-	}
-
-	c.Tags = strings.Join(temp, ",")
+	c.Tags = AddValue(c.Tags, tags...)
 }
 
 // The Go Struct Version for ComicPageInfo, used to store page information.

--- a/internal/comicinfo/ComicInfo_test.go
+++ b/internal/comicinfo/ComicInfo_test.go
@@ -61,7 +61,7 @@ func TestAddTags(t *testing.T) {
 		tt.c.AddTags(tt.tags...)
 
 		// Validate valid
-		assert.EqualValuesf(t, tt.c.Tags, tt.wantedTags, "Case %d: not expected value.", idx)
+		assert.EqualValuesf(t, tt.wantedTags, tt.c.Tags, "Case %d: not expected value.", idx)
 	}
 }
 

--- a/internal/comicinfo/utils.go
+++ b/internal/comicinfo/utils.go
@@ -1,0 +1,62 @@
+package comicinfo
+
+import (
+	"maps"
+	"slices"
+	"strings"
+)
+
+var Separator string = ","
+
+// Split value by Separator that can be set by comicinfo.Separator.
+func splitValue(str string) []string {
+	list := strings.Split(str, Separator)
+
+	result := make([]string, 0)
+
+	for _, item := range list {
+		str := strings.TrimSpace(item)
+
+		if str == "" {
+			continue
+		}
+
+		result = append(result, str)
+	}
+
+	return result
+}
+
+// Remove duplicate item from given string slice.
+func removeDuplicates(items []string) []string {
+	m := make(map[string]struct{})
+
+	for _, item := range items {
+		str := strings.TrimSpace(item)
+		m[str] = struct{}{}
+	}
+
+	result := make([]string, 0)
+	for i := range maps.Keys(m) {
+		result = append(result, i)
+	}
+
+	// Sort slice to prevent race condition
+	slices.Sort(result)
+	return result
+}
+
+// Add values to given string, by separator.
+// This function will also ensure no duplicate item appear in final string.
+func AddValue(str string, values ...string) string {
+	// Split original string to items
+	parsed := splitValue(str)
+
+	// Add values
+	parsed = append(parsed, values...)
+
+	// Remove duplicate values
+	parsed = removeDuplicates(parsed)
+
+	return strings.Join(parsed, Separator)
+}

--- a/internal/comicinfo/utils_test.go
+++ b/internal/comicinfo/utils_test.go
@@ -1,0 +1,41 @@
+package comicinfo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveDuplicates(t *testing.T) {
+	tests := []struct {
+		args []string
+		want []string
+	}{
+		{[]string{"item1", "item2"}, []string{"item1", "item2"}},
+		{[]string{"item1", "item1"}, []string{"item1"}},
+		{[]string{"item1", "item1 "}, []string{"item1"}},
+		{[]string{"item1"}, []string{"item1"}},
+		{[]string{}, []string{}},
+	}
+
+	for idx, tt := range tests {
+		assert.EqualValuesf(t, tt.want, removeDuplicates(tt.args), "Unexpected value in case %d", idx)
+	}
+}
+
+func TestSplitValue(t *testing.T) {
+	tests := []struct {
+		str  string
+		want []string
+	}{
+		{"item1,item2,item3", []string{"item1", "item2", "item3"}},
+		{"item1, item2, item3", []string{"item1", "item2", "item3"}},
+		{"item1,,item3", []string{"item1", "item3"}},
+		{"item", []string{"item"}},
+		{"", []string{}},
+	}
+
+	for idx, tt := range tests {
+		assert.EqualValuesf(t, tt.want, splitValue(tt.str), "Unexpected result in case %d", idx)
+	}
+}


### PR DESCRIPTION
### Changes Made

Add support to append value by separator in comicinfo struct.

### Reason of Changes

For autofill version developing.

### Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have create/modify corresponding test for new changes
-   [x] I have made corresponding changes to the documentation
-   [x] I have run all new & existing test and pass locally with my changes
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request
