### PR TITLE
Fix incorrect usage on `testify/assert`

### DIFF
--- a/internal/application/export_test.go
+++ b/internal/application/export_test.go
@@ -329,9 +329,9 @@ func TestSoftDelete(t *testing.T) {
 		msg := app.RunSoftDelete()
 
 		if tt.wantErr {
-			assert.NotEmpty(t, msg, "Case %d should be not empty", idx)
+			assert.NotEmptyf(t, msg, "Case %d should be not empty", idx)
 		} else {
-			assert.Empty(t, msg, "Case %d should be empty", idx)
+			assert.Emptyf(t, msg, "Case %d should be empty", idx)
 		}
 	}
 

--- a/internal/archive/soft_delete_test.go
+++ b/internal/archive/soft_delete_test.go
@@ -38,12 +38,12 @@ func TestSoftDeleteComic(t *testing.T) {
 		err := SoftDeleteComic(tt.originDir, tt.trashBin)
 
 		if tt.wantErr {
-			assert.Error(t, err, "Case %d : SoftDelete should return an error", idx)
+			assert.Errorf(t, err, "Case %d : SoftDelete should return an error", idx)
 			continue
 		}
 
 		// Check no error and directory
-		assert.NoError(t, err, "Case %d : SoftDelete should not return an error", idx)
+		assert.NoErrorf(t, err, "Case %d : SoftDelete should not return an error", idx)
 
 		// Check if directory moved successfully
 		expectedDest := filepath.Join(tt.trashBin, filepath.Base(tt.originDir))

--- a/internal/archive/zip_test.go
+++ b/internal/archive/zip_test.go
@@ -62,7 +62,7 @@ func TestCreateZipTo(t *testing.T) {
 
 		// Start Testing Functions
 		dest, err := CreateZipTo(inputDir, outputDir)
-		assert.Nil(t, err, "Unexpected error")
+		assert.NoError(t, err, "Unexpected error when create zip")
 
 		// Check Dest Filename
 		assert.EqualValuesf(t, dest, filepath.Join(tempDir, tt.destZip), "Error destination file.")

--- a/internal/autofill/autofill_test.go
+++ b/internal/autofill/autofill_test.go
@@ -93,7 +93,7 @@ func TestAutoFillRun(t *testing.T) {
 	for idx, tt := range tests {
 		info, err := r.Run(tt.bookname)
 		if err != nil {
-			assert.Nilf(t, err, "No error should be generate in case %d", idx)
+			assert.NoErrorf(t, err, "No error should be generate in case %d", idx)
 			continue
 		}
 

--- a/internal/comicinfo/convert_test.go
+++ b/internal/comicinfo/convert_test.go
@@ -152,7 +152,11 @@ func TestLoad(t *testing.T) {
 		got, err := Load(tt.path)
 
 		// Check error is wanted
-		assert.Equalf(t, err != nil, tt.wantErr, "Case %d: Expected has any error: %v, but %v", idx, tt.wantErr, err)
+		if tt.wantErr {
+			assert.Errorf(t, err, "Case %d: Expected error, but no error return.", idx)
+		} else {
+			assert.NoErrorf(t, err, "Case %d: Unwanted error.", idx)
+		}
 
 		// Check comic info value
 		assert.EqualValues(t, got, tt.want, "Case %d: values not equals", idx)
@@ -188,7 +192,11 @@ func TestSave(t *testing.T) {
 		err := Save(tt.info, tt.path)
 
 		// Check error is expected
-		assert.Equalf(t, err != nil, tt.wantErr, "Case %d: Expected has any error: %v, but %v", idx, tt.wantErr, err)
+		if tt.wantErr {
+			assert.Errorf(t, err, "Case %d: Expected error, but no error return.", idx)
+		} else {
+			assert.NoErrorf(t, err, "Case %d: Unwanted error.", idx)
+		}
 
 		// Early return if nothing is expected to compare
 		if tt.wantedPath == PATH_NO_COMPARE {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -45,14 +45,14 @@ func TestLoadYaml(t *testing.T) {
 		c, err := LoadYaml(tt.path)
 
 		if tt.wantErr {
-			assert.NotNilf(t, err, "Error should be returned in case %d, but return nil", idx)
+			assert.Errorf(t, err, "Error should be returned in case %d, but return nil", idx)
 
 			// Ensure default is returned
 			assert.EqualValuesf(t, Default(), c, "Incorrect values in case %d, should be default config", idx)
 
 		} else {
 			assert.EqualValuesf(t, tt.want, c, "Incorrect values in case %d", idx)
-			assert.Nilf(t, err, "Unexpected error in case %d", idx)
+			assert.NoErrorf(t, err, "Unexpected error in case %d", idx)
 		}
 	}
 }

--- a/internal/history/core_test.go
+++ b/internal/history/core_test.go
@@ -119,11 +119,14 @@ func TestInsertValue(t *testing.T) {
 		// Perform function
 		err = insertValue(db, tt.category, tt.value...)
 
-		// Asset no error occur
-		assert.EqualValuesf(t, tt.wantErr, err != nil, "Case %d: Expected has error=%t, got %t", idx, tt.wantErr, err != nil)
+		// If error expected, check error and contine test as no value need to check
 		if tt.wantErr {
+			assert.Errorf(t, err, "Case %d: Expected error, but return nil", idx)
 			continue
 		}
+
+		// Asset no error occur
+		assert.NoErrorf(t, err, "Case %d: Unwanted error.", idx)
 
 		// Asset value has inserted
 		for i, val := range tt.value {
@@ -162,11 +165,15 @@ func TestGetHistory(t *testing.T) {
 	}
 
 	// Start Testing
-	for _, tt := range tests {
+	for idx, tt := range tests {
 		results, err := getHistory(a, tt.category)
 
 		// Check error
-		assert.EqualValuesf(t, tt.wantErr, err != nil, "expected error=%v, but error=%v", tt.wantErr, err)
+		if tt.wantErr {
+			assert.Errorf(t, err, "Case %d: expected error, but nil returned", idx)
+		} else {
+			assert.NoErrorf(t, err, "Case %d: Unwanted error", idx)
+		}
 
 		// Check values
 		assert.EqualValuesf(t, tt.result, results, "unexpected output, expect=%v, got=%v", tt.result, results)
@@ -189,14 +196,17 @@ func TestGetHistoryNilDB(t *testing.T) {
 	}
 
 	// Start Testing
-	for _, tt := range tests {
+	for idx, tt := range tests {
 		results, err := getHistory(a, tt.category)
 
-		// Check error
-		assert.EqualValuesf(t, tt.wantErr, err != nil, "expected error=%v, but error=%v", tt.wantErr, err)
+		// If want error, then check error and skip value checking
 		if tt.wantErr {
+			assert.Errorf(t, err, "Case %d: Expected error, but nil returned.", idx)
 			continue
 		}
+
+		// Check error
+		assert.NoErrorf(t, err, "Case %d: Unwanted error.", idx)
 
 		// Check values
 		assert.EqualValuesf(t, tt.result, results, "unexpected output, expect=%v, got=%v", tt.result, results)

--- a/internal/history/multiple_test.go
+++ b/internal/history/multiple_test.go
@@ -69,11 +69,14 @@ func TestInsertMultiple(t *testing.T) {
 		// Perform function
 		err = InsertMultiple(db, tt.values...)
 
-		// Asset no error occur
-		assert.EqualValuesf(t, tt.wantErr, err != nil, "Case %d: Expected has error=%t, got %t", idx, tt.wantErr, err != nil)
+		// If error expected, check error and contine test as no value need to check
 		if tt.wantErr {
+			assert.Errorf(t, err, "Case %d: Expected error, but return nil", idx)
 			continue
 		}
+
+		// Asset no error occur
+		assert.NoErrorf(t, err, "Case %d: Unwanted error.", idx)
 
 		// Asset value has inserted
 		for i, val := range tt.values {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -119,7 +119,11 @@ func TestScanBooks(t *testing.T) {
 		got, err := ScanBooks(tt.folderPath)
 
 		// Error Checking
-		assert.EqualValuesf(t, tt.wantErr, err != nil, "Case %d: unexpected error result: %v", idx, err)
+		if tt.wantErr {
+			assert.Errorf(t, err, "Case %d: Expected error, but no error return.", idx)
+		} else {
+			assert.NoErrorf(t, err, "Case %d: Unwanted error.", idx)
+		}
 
 		// Value checking
 		assert.EqualValuesf(t, tt.want, got, "Case %d: Not equal comicInfo", idx)

--- a/internal/tagger/db_test.go
+++ b/internal/tagger/db_test.go
@@ -125,11 +125,14 @@ func TestAddTag(t *testing.T) {
 		// Perform function
 		err = AddTag(db, tt.tags...)
 
-		// Asset no error occur
-		assert.EqualValuesf(t, tt.wantErr, err != nil, "Case %d: Expected has error=%t, got %t", idx, tt.wantErr, err != nil)
+		// If error expected, check error and contine test as no value need to check
 		if tt.wantErr {
+			assert.Errorf(t, err, "Case %d: Expected error, but return nil", idx)
 			continue
 		}
+
+		// Asset no error occur
+		assert.NoErrorf(t, err, "Case %d: Unwanted error.", idx)
 
 		// Asset value has inserted
 		for i, val := range tt.tags {
@@ -193,7 +196,11 @@ func TestGetAllTags(t *testing.T) {
 		results, err := GetAllTags(tt.db)
 
 		// Check error
-		assert.EqualValuesf(t, tt.wantErr, err != nil, "case %d: expected error=%v, but error=%v", idx, tt.wantErr, err)
+		if tt.wantErr {
+			assert.Errorf(t, err, "Case %d: Expected error, but no error return.", idx)
+		} else {
+			assert.NoErrorf(t, err, "Case %d: Unwanted error.", idx)
+		}
 
 		// Check values
 		assert.EqualValuesf(t, tt.results, results, "case %d: unexpected output, expect=%v, got=%v", idx, tt.results, results)


### PR DESCRIPTION
### Changes Made

- Use `NotEmptyf` and `Emptyf` for message with arguments
- Use `NoErrorf` and `Errorf` for error checking instead of `Nilf` or `Equalf`

### Reason of Changes

Close #160 

### Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have create/modify corresponding test for new changes
-   [x] I have made corresponding changes to the documentation
-   [x] I have run all new & existing test and pass locally with my changes
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request
