### PR TITLE
Move folder checking code to `dircheck` package

### DIFF
--- a/internal/README.md
+++ b/internal/README.md
@@ -14,40 +14,8 @@ The package to convert image directory to `.zip` and `.cbz` file.
 
 Package to control database & schema, and some fixed environment constants.
 
-## Autofill
-
-Package to control autofill behavior for comicinfo, based on database record and bookname.
-
-Bookname will be separate to multiple keyword by space, while database store user inputted record.
-
 ## comicinfo
 
 The [ComicInfo.xml](https://anansi-project.github.io/docs/comicinfo/documentation) Structure in `Go`, Converted from `ComicInfo.xsd`.
 
 Current Schema version is `2.1`.
-
-## files
-
-The package contains multiple utility function for files system.
-
-## history
-
-The package to control record of database, specially user inputted values.
-
-## parser
-
-Utils Package. Extract information from filename/directory name to comicInfo.
-
-Currently Support `Author`, `Title`, also for identify special tags.
-
-## scanner
-
-The package for scanner image directory.
-
-This package will produce a `ComicInfo` Struct, which contains pages detail, and also information that extract from `parser` package.
-
-## tagger
-
-Package for handle tags record in database, include user inputted values.
-
-This package is separate from `history` package due to tags handling can be complex when compare with other user inputted values.

--- a/internal/application/comicinfo.go
+++ b/internal/application/comicinfo.go
@@ -32,7 +32,7 @@ func (a *App) GetComicInfo(folder string) ComicInfoResponse {
 	}
 
 	// Validate the directory
-	isValid, err := dircheck.CheckFolder(absPath, dircheck.ScanOpt{SubFolder: dircheck.Reject, Image: dircheck.Allow})
+	isValid, err := dircheck.CheckFolder(absPath, dircheck.DirectoryOpt{SubFolder: dircheck.Reject, Image: dircheck.Allow})
 	if err != nil {
 		return ComicInfoResponse{
 			ComicInfo:    nil,

--- a/internal/application/comicinfo.go
+++ b/internal/application/comicinfo.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dark-person/comicinfo-parser/internal/dataprovider"
 	"github.com/dark-person/comicinfo-parser/internal/dataprovider/fsprov"
 	"github.com/dark-person/comicinfo-parser/internal/dataprovider/historyprov"
+	"github.com/dark-person/comicinfo-parser/internal/dircheck"
 )
 
 type ComicInfoResponse struct {
@@ -31,7 +32,7 @@ func (a *App) GetComicInfo(folder string) ComicInfoResponse {
 	}
 
 	// Validate the directory
-	isValid, err := fsprov.CheckFolder(absPath, fsprov.ScanOpt{SubFolder: fsprov.Reject, Image: fsprov.Allow})
+	isValid, err := dircheck.CheckFolder(absPath, dircheck.ScanOpt{SubFolder: dircheck.Reject, Image: dircheck.Allow})
 	if err != nil {
 		return ComicInfoResponse{
 			ComicInfo:    nil,

--- a/internal/application/export.go
+++ b/internal/application/export.go
@@ -37,7 +37,7 @@ func (a *App) QuickExportKomga(inputDir string) string {
 	}
 
 	// Validate the directory
-	isValid, err := dircheck.CheckFolder(inputDir, dircheck.ScanOpt{SubFolder: dircheck.Reject, Image: dircheck.Allow})
+	isValid, err := dircheck.CheckFolder(inputDir, dircheck.DirectoryOpt{SubFolder: dircheck.Reject, Image: dircheck.Allow})
 	if err != nil {
 		return err.Error()
 	} else if !isValid {

--- a/internal/application/export.go
+++ b/internal/application/export.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dark-person/comicinfo-parser/internal/dataprovider"
 	"github.com/dark-person/comicinfo-parser/internal/dataprovider/fsprov"
 	"github.com/dark-person/comicinfo-parser/internal/definitions"
+	"github.com/dark-person/comicinfo-parser/internal/dircheck"
 	"github.com/dark-person/comicinfo-parser/internal/store"
 	"github.com/sirupsen/logrus"
 )
@@ -36,7 +37,7 @@ func (a *App) QuickExportKomga(inputDir string) string {
 	}
 
 	// Validate the directory
-	isValid, err := fsprov.CheckFolder(inputDir, fsprov.ScanOpt{SubFolder: fsprov.Reject, Image: fsprov.Allow})
+	isValid, err := dircheck.CheckFolder(inputDir, dircheck.ScanOpt{SubFolder: dircheck.Reject, Image: dircheck.Allow})
 	if err != nil {
 		return err.Error()
 	} else if !isValid {

--- a/internal/dataprovider/fsprov/provider.go
+++ b/internal/dataprovider/fsprov/provider.go
@@ -37,7 +37,7 @@ func GetPageInfo(absPath string) (pages []comicinfo.ComicPageInfo, err error) {
 	// Image must be re-scan due to image contents may changed
 	imageIdx := 0
 	for _, entry := range entries {
-		if !isSupportedImg(entry.Name()) {
+		if !files.IsSupportedImg(entry.Name()) {
 			continue
 		}
 

--- a/internal/dataprovider/fsprov/validation.go
+++ b/internal/dataprovider/fsprov/validation.go
@@ -3,6 +3,8 @@ package fsprov
 import (
 	"fmt"
 	"os"
+
+	"github.com/dark-person/comicinfo-parser/internal/files"
 )
 
 // Check the folder fulfill requirement of the given Scanner Options
@@ -33,7 +35,7 @@ func CheckFolder(folderPath string, opt ScanOpt) (bool, error) {
 		}
 
 		// Image Extension check
-		if isSupportedImg(entry.Name()) {
+		if files.IsSupportedImg(entry.Name()) {
 			imageCount++
 			continue
 		}

--- a/internal/dircheck/checker.go
+++ b/internal/dircheck/checker.go
@@ -7,8 +7,8 @@ import (
 	"github.com/dark-person/comicinfo-parser/internal/files"
 )
 
-// Check the folder fulfill requirement of the given Scanner Options
-func CheckFolder(folderPath string, opt ScanOpt) (bool, error) {
+// Check the folder fulfill requirement of the given Directory option.
+func CheckFolder(folderPath string, opt DirectoryOpt) (bool, error) {
 	if !opt.Valid() {
 		return false, fmt.Errorf("invalid scan options")
 	}

--- a/internal/dircheck/checker.go
+++ b/internal/dircheck/checker.go
@@ -1,4 +1,4 @@
-package fsprov
+package dircheck
 
 import (
 	"fmt"

--- a/internal/dircheck/checker.go
+++ b/internal/dircheck/checker.go
@@ -1,3 +1,4 @@
+// Package to check folder is valid to process or not.
 package dircheck
 
 import (

--- a/internal/dircheck/checker_test.go
+++ b/internal/dircheck/checker_test.go
@@ -34,55 +34,55 @@ func TestCheckFolder(t *testing.T) {
 	// Start Image Test
 	var tests = []struct {
 		path     string
-		opt      ScanOpt
+		opt      DirectoryOpt
 		want     bool
 		hasError bool
 	}{
 		// Image Opt Test (1~12)
-		{path1, ScanOpt{Image: Unspecific}, true, false},
-		{path1, ScanOpt{Image: Allow}, true, false},
-		{path1, ScanOpt{Image: AllowOnly}, true, false},
-		{path1, ScanOpt{Image: Reject}, false, false},
+		{path1, DirectoryOpt{Image: Unspecific}, true, false},
+		{path1, DirectoryOpt{Image: Allow}, true, false},
+		{path1, DirectoryOpt{Image: AllowOnly}, true, false},
+		{path1, DirectoryOpt{Image: Reject}, false, false},
 
-		{path2, ScanOpt{Image: Unspecific}, true, false},
-		{path2, ScanOpt{Image: Allow}, false, false},
-		{path2, ScanOpt{Image: AllowOnly}, false, false},
-		{path2, ScanOpt{Image: Reject}, true, false},
+		{path2, DirectoryOpt{Image: Unspecific}, true, false},
+		{path2, DirectoryOpt{Image: Allow}, false, false},
+		{path2, DirectoryOpt{Image: AllowOnly}, false, false},
+		{path2, DirectoryOpt{Image: Reject}, true, false},
 
-		{path3, ScanOpt{Image: Unspecific}, true, false},
-		{path3, ScanOpt{Image: Allow}, true, false},
-		{path3, ScanOpt{Image: AllowOnly}, false, false},
-		{path3, ScanOpt{Image: Reject}, false, false},
+		{path3, DirectoryOpt{Image: Unspecific}, true, false},
+		{path3, DirectoryOpt{Image: Allow}, true, false},
+		{path3, DirectoryOpt{Image: AllowOnly}, false, false},
+		{path3, DirectoryOpt{Image: Reject}, false, false},
 
-		{path4, ScanOpt{Image: Unspecific}, true, false},
-		{path4, ScanOpt{Image: Allow}, false, false},
-		{path4, ScanOpt{Image: AllowOnly}, false, false},
-		{path4, ScanOpt{Image: Reject}, true, false},
+		{path4, DirectoryOpt{Image: Unspecific}, true, false},
+		{path4, DirectoryOpt{Image: Allow}, false, false},
+		{path4, DirectoryOpt{Image: AllowOnly}, false, false},
+		{path4, DirectoryOpt{Image: Reject}, true, false},
 
 		// Subfolder Test (13~24)
-		{path1, ScanOpt{SubFolder: Unspecific}, true, false},
-		{path1, ScanOpt{SubFolder: Allow}, false, false},
-		{path1, ScanOpt{SubFolder: AllowOnly}, false, false},
-		{path1, ScanOpt{SubFolder: Reject}, true, false},
+		{path1, DirectoryOpt{SubFolder: Unspecific}, true, false},
+		{path1, DirectoryOpt{SubFolder: Allow}, false, false},
+		{path1, DirectoryOpt{SubFolder: AllowOnly}, false, false},
+		{path1, DirectoryOpt{SubFolder: Reject}, true, false},
 
-		{path2, ScanOpt{SubFolder: Unspecific}, true, false},
-		{path2, ScanOpt{SubFolder: Allow}, true, false},
-		{path2, ScanOpt{SubFolder: AllowOnly}, true, false},
-		{path2, ScanOpt{SubFolder: Reject}, false, false},
+		{path2, DirectoryOpt{SubFolder: Unspecific}, true, false},
+		{path2, DirectoryOpt{SubFolder: Allow}, true, false},
+		{path2, DirectoryOpt{SubFolder: AllowOnly}, true, false},
+		{path2, DirectoryOpt{SubFolder: Reject}, false, false},
 
-		{path3, ScanOpt{SubFolder: Unspecific}, true, false},
-		{path3, ScanOpt{SubFolder: Allow}, true, false},
-		{path3, ScanOpt{SubFolder: AllowOnly}, false, false},
-		{path3, ScanOpt{SubFolder: Reject}, false, false},
+		{path3, DirectoryOpt{SubFolder: Unspecific}, true, false},
+		{path3, DirectoryOpt{SubFolder: Allow}, true, false},
+		{path3, DirectoryOpt{SubFolder: AllowOnly}, false, false},
+		{path3, DirectoryOpt{SubFolder: Reject}, false, false},
 
-		{path4, ScanOpt{SubFolder: Unspecific}, true, false},
-		{path4, ScanOpt{SubFolder: Allow}, false, false},
-		{path4, ScanOpt{SubFolder: AllowOnly}, false, false},
-		{path4, ScanOpt{SubFolder: Reject}, true, false},
+		{path4, DirectoryOpt{SubFolder: Unspecific}, true, false},
+		{path4, DirectoryOpt{SubFolder: Allow}, false, false},
+		{path4, DirectoryOpt{SubFolder: AllowOnly}, false, false},
+		{path4, DirectoryOpt{SubFolder: Reject}, true, false},
 
 		// Contradiction Test
-		{path3, ScanOpt{SubFolder: AllowOnly, Image: Allow}, false, true},
-		{path3, ScanOpt{Image: AllowOnly, SubFolder: Allow}, false, true},
+		{path3, DirectoryOpt{SubFolder: AllowOnly, Image: Allow}, false, true},
+		{path3, DirectoryOpt{Image: AllowOnly, SubFolder: Allow}, false, true},
 	}
 
 	// Loop the test case and check the result

--- a/internal/dircheck/checker_test.go
+++ b/internal/dircheck/checker_test.go
@@ -1,4 +1,4 @@
-package fsprov
+package dircheck
 
 import (
 	"os"

--- a/internal/dircheck/option.go
+++ b/internal/dircheck/option.go
@@ -1,6 +1,6 @@
 package dircheck
 
-// The type for limit developer to pass in ScanOpt
+// The type for limit developer to pass in DirectoryOpt
 type optEnum int
 
 const (
@@ -15,7 +15,7 @@ const (
 )
 
 // The option for dircheck package.
-type ScanOpt struct {
+type DirectoryOpt struct {
 	// Option for given path has any sub-folder
 	SubFolder optEnum
 
@@ -23,8 +23,8 @@ type ScanOpt struct {
 	Image optEnum
 }
 
-// Check the ScanOpt is valid for process, prevent contradiction among fields.
-func (opt *ScanOpt) Valid() bool {
+// Check the DirOpt is valid for process, prevent contradiction among fields.
+func (opt *DirectoryOpt) Valid() bool {
 	if opt.Image == AllowOnly && (opt.SubFolder == Allow || opt.SubFolder == AllowOnly) {
 		return false
 	}

--- a/internal/dircheck/option.go
+++ b/internal/dircheck/option.go
@@ -1,4 +1,4 @@
-package fsprov
+package dircheck
 
 // The type for limit developer to pass in ScanOpt
 type optEnum int
@@ -14,7 +14,7 @@ const (
 	Reject
 )
 
-// The option for scanner package.
+// The option for dircheck package.
 type ScanOpt struct {
 	// Option for given path has any sub-folder
 	SubFolder optEnum

--- a/internal/files/images.go
+++ b/internal/files/images.go
@@ -1,4 +1,4 @@
-package fsprov
+package files
 
 import (
 	"path/filepath"
@@ -6,7 +6,7 @@ import (
 )
 
 // Check if image file extension is supported.
-func isSupportedImg(filename string) bool {
+func IsSupportedImg(filename string) bool {
 	ext := filepath.Ext(filename)
 	ext = strings.ToLower(ext)
 	return ext == ".jpg" || ext == ".png" || ext == ".jpeg" || ext == ".webp"

--- a/internal/files/images_test.go
+++ b/internal/files/images_test.go
@@ -1,4 +1,4 @@
-package fsprov
+package files
 
 import (
 	"testing"
@@ -25,6 +25,6 @@ func TestIsSupportedImg(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.want, isSupportedImg(tt.filename))
+		assert.Equal(t, tt.want, IsSupportedImg(tt.filename))
 	}
 }


### PR DESCRIPTION
### Changes Made

- Move folder checking logic to package `dircheck`
- Move `isSupportedImg` to `files` package and accessible by other package
- Rename `ScanOpt` to `DirectoryOpt`

### Reason of Changes

Close #165 .

### Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have create/modify corresponding test for new changes
-   [x] I have made corresponding changes to the documentation
-   [x] I have run all new & existing test and pass locally with my changes
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request
