### PR TITLE
Allow user to config comicinfo "Number" field default value by `config.yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,17 @@ You may found a sample of configuration file in `config-example.yaml`, and defau
 
 You should use absolute paths as possible. If folder is missing, then program will try to create for all folders.
 
-| Field                   | Type   | Usage                                                          | When value is empty                                |
-| ----------------------- | ------ | -------------------------------------------------------------- | -------------------------------------------------- |
-| `default`               | struct | storing default values for program                             | N/a                                                |
-| `default.export-folder` | string | default export folder path                                     | create inside input directory                      |
-| `default.comic-folder`  | string | default folder location when choose folder to create comicinfo | Folder select UI will be empty                     |
-| `trash-bin`             | struct | Store trash bin definition for soft-deletion                   | N/a                                                |
-| `trash-bin.path`        | string | path of program trash bin                                      | no soft-deletion operation                         |
-| `database`              | struct | Database related settings                                      | N/a                                                |
-| `database.path`         | string | path of database                                               | use `{Home Directory}/comicInfo-parser/storage.db` |
+| Field                     | Type   | Usage                                                          | When value is empty                                |
+| ------------------------- | ------ | -------------------------------------------------------------- | -------------------------------------------------- |
+| `default`                 | struct | storing default values for program                             | N/a                                                |
+| `default.export-folder`   | string | default export folder path                                     | create inside input directory                      |
+| `default.comic-folder`    | string | default folder location when choose folder to create comicinfo | Folder select UI will be empty                     |
+| `trash-bin`               | struct | Store trash bin definition for soft-deletion                   | N/a                                                |
+| `trash-bin.path`          | string | path of program trash bin                                      | no soft-deletion operation                         |
+| `database`                | struct | Database related settings                                      | N/a                                                |
+| `database.path`           | string | path of database                                               | use `{Home Directory}/comicInfo-parser/storage.db` |
+| `metadata`                | struct | Default Metadata values                                        | N/a                                                |
+| `metadata.default-number` | string | `Number` in comicinfo                                          | use empty value                                    |
 
 ## Data
 

--- a/config-default.yaml
+++ b/config-default.yaml
@@ -5,5 +5,8 @@ default:
 database:
     path:
 
+metadata:
+    default-number:
+
 trash-bin:
     path:

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -5,5 +5,8 @@ default:
 database:
     path: "./my-data.db"
 
+metadata:
+    default-number: "1"
+
 trash-bin:
     path: "./.trash"

--- a/internal/application/comicinfo.go
+++ b/internal/application/comicinfo.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dark-person/comicinfo-parser/internal/comicinfo"
 	"github.com/dark-person/comicinfo-parser/internal/dataprovider"
+	"github.com/dark-person/comicinfo-parser/internal/dataprovider/cfgprov"
 	"github.com/dark-person/comicinfo-parser/internal/dataprovider/fsprov"
 	"github.com/dark-person/comicinfo-parser/internal/dataprovider/historyprov"
 	"github.com/dark-person/comicinfo-parser/internal/dircheck"
@@ -64,6 +65,15 @@ func (a *App) GetComicInfo(folder string) ComicInfoResponse {
 
 	// Autofill by file base name
 	prov = historyprov.New(a.DB, filepath.Base(absPath))
+	c, err = prov.Fill(c)
+
+	// Consider as acceptable error, log error only
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	// Fill by configuration
+	prov = cfgprov.New(a.cfg)
 	c, err = prov.Fill(c)
 
 	// Consider as acceptable error, log error only

--- a/internal/application/export.go
+++ b/internal/application/export.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dark-person/comicinfo-parser/internal/archive"
 	"github.com/dark-person/comicinfo-parser/internal/comicinfo"
 	"github.com/dark-person/comicinfo-parser/internal/dataprovider"
+	"github.com/dark-person/comicinfo-parser/internal/dataprovider/cfgprov"
 	"github.com/dark-person/comicinfo-parser/internal/dataprovider/fsprov"
 	"github.com/dark-person/comicinfo-parser/internal/definitions"
 	"github.com/dark-person/comicinfo-parser/internal/dircheck"
@@ -55,6 +56,15 @@ func (a *App) QuickExportKomga(inputDir string) string {
 	c, err = prov.Fill(c)
 	if err != nil {
 		return err.Error()
+	}
+
+	// Fill by configuration
+	prov = cfgprov.New(a.cfg)
+	c, err = prov.Fill(c)
+
+	// Consider as acceptable error, log error only
+	if err != nil {
+		fmt.Println(err)
 	}
 
 	// Write ComicInfo.xml

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -27,6 +27,9 @@ func TestLoadYaml(t *testing.T) {
 				ExportDir: filepath.Join(exPath, "./my-export"),
 				ComicDir:  filepath.Join(exPath, "./my-input"),
 			},
+			Metadata: metadataConfig{
+				Number: "1",
+			},
 			Database: databaseConfig{
 				Path: filepath.Join(exPath, "./my-data.db"),
 			},

--- a/internal/config/mock/case-empty.yaml
+++ b/internal/config/mock/case-empty.yaml
@@ -2,6 +2,9 @@ default:
     export-folder:
     comic-folder:
 
+metadata:
+    default-number:
+
 database:
     path:
 

--- a/internal/config/mock/case-normal.yaml
+++ b/internal/config/mock/case-normal.yaml
@@ -2,6 +2,9 @@ default:
     export-folder: ./my-export
     comic-folder: ./my-input
 
+metadata:
+    default-number: 1
+
 database:
     path: "./my-data.db"
 

--- a/internal/config/mock/case-typo1.yaml
+++ b/internal/config/mock/case-typo1.yaml
@@ -2,6 +2,9 @@ defaults:
     export-folder: ./my-export
     comic-folder: ./my-input
 
+metadatas:
+    default-number: 1
+
 databases:
     path: "./my-data.db"
 

--- a/internal/config/mock/case-typo2.yaml
+++ b/internal/config/mock/case-typo2.yaml
@@ -2,6 +2,9 @@ default:
     exports-folder: ./my-export
     comics-folder: ./my-input
 
+metadata:
+    default-numbers: 1
+
 database:
     paths: "./my-data.db"
 

--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -5,6 +5,7 @@ package config
 // Config for this program.
 type ProgramConfig struct {
 	Folder   folderConfig   `koanf:"default"`   // Config setting for folders
+	Metadata metadataConfig `koanf:"metadata"`  // Config for metadata default values
 	Database databaseConfig `koanf:"database"`  // Config for database to use
 	TrashBin trashBinConfig `koanf:"trash-bin"` // Config of trash bin usage
 }
@@ -13,6 +14,11 @@ type ProgramConfig struct {
 type folderConfig struct {
 	ComicDir  string `koanf:"comic-folder"`  // Default input directory, all folder select dialog will start from here
 	ExportDir string `koanf:"export-folder"` // Default export folder, apply to both quick & standard
+}
+
+// Configuration for default value of metadata.
+type metadataConfig struct {
+	Number string `koanf:"default-number"`
 }
 
 // Config for database setting.
@@ -31,6 +37,9 @@ func Default() *ProgramConfig {
 		Folder: folderConfig{
 			ComicDir:  "", // Indicate use wails default directory
 			ExportDir: "", // Indicate input folder is used
+		},
+		Metadata: metadataConfig{
+			Number: "",
 		},
 		Database: databaseConfig{
 			Path: "", // Indicate default database location is used

--- a/internal/dataprovider/cfgprov/provider.go
+++ b/internal/dataprovider/cfgprov/provider.go
@@ -1,0 +1,42 @@
+// Package to get comicinfo data from config,
+// which is the program config that used by application and retrieve from program start.
+package cfgprov
+
+import (
+	"fmt"
+
+	"github.com/dark-person/comicinfo-parser/internal/comicinfo"
+	"github.com/dark-person/comicinfo-parser/internal/config"
+	"github.com/dark-person/comicinfo-parser/internal/dataprovider"
+)
+
+// Data provider that use default value stated in configuration.
+type ConfigProvider struct {
+	cfg *config.ProgramConfig
+}
+
+var _ dataprovider.DataProvider = (*ConfigProvider)(nil)
+
+// Create a new data provider that use default value stated in configuration.
+func New(cfg *config.ProgramConfig) *ConfigProvider {
+	return &ConfigProvider{cfg: cfg}
+}
+
+// Fill input comicinfo by configuration.
+// There has two possiblity of fill method:
+//
+//  1. Fill success, return changed comicinfo and nil error
+//  2. Fill failed, return unchanged comicinfo (same as input) and error it self
+func (c *ConfigProvider) Fill(input *comicinfo.ComicInfo) (result *comicinfo.ComicInfo, err error) {
+	// Ensure configuration is not empty
+	if c.cfg == nil {
+		return input, fmt.Errorf("configuration cannot be nil")
+	}
+
+	// Fill values
+	if c.cfg.Metadata.Number != "" {
+		input.Number = c.cfg.Metadata.Number
+	}
+
+	return input, nil
+}

--- a/internal/dataprovider/cfgprov/provider_test.go
+++ b/internal/dataprovider/cfgprov/provider_test.go
@@ -1,0 +1,57 @@
+package cfgprov
+
+import (
+	"testing"
+
+	"github.com/dark-person/comicinfo-parser/internal/comicinfo"
+	"github.com/dark-person/comicinfo-parser/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProvider(t *testing.T) {
+	// Prepare test case values
+	configured1 := config.Default()
+	configured1.Metadata.Number = "1.5"
+
+	configured2 := config.Default()
+	configured2.Metadata.Number = "2"
+
+	info1 := comicinfo.New()
+	info1.Number = "1.5"
+
+	info2 := comicinfo.New()
+	info2.Number = "2"
+
+	// ----------------------------------------
+
+	// Prepare Test cases, which error must not allowed
+	type testCase struct {
+		cfg     *config.ProgramConfig // configuration
+		want    comicinfo.ComicInfo   // expected comicinfo
+		wantErr bool                  // If error will occur
+	}
+
+	tests := []testCase{
+		{config.Default(), comicinfo.New(), false},
+		{configured1, info1, false},
+		{configured2, info2, false},
+		{nil, comicinfo.New(), true},
+	}
+
+	// Start test
+	for idx, tt := range tests {
+		// Prepare new comicinfo
+		tc := comicinfo.New()
+		c := &tc
+
+		// Run provider
+		prov := New(tt.cfg)
+		c, err := prov.Fill(c)
+
+		if tt.wantErr {
+			assert.Errorf(t, err, "Case %d: Expected error occur but nil.", idx)
+		} else {
+			assert.EqualValuesf(t, &tt.want, c, "Case %d: Unexpected comicinfo result", idx)
+		}
+	}
+}


### PR DESCRIPTION
### Changes Made

Create new provider to use config to fill comicinfo: Support number field only.

### Reason of Changes

Close #157 .

### Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have create/modify corresponding test for new changes
-   [x] I have made corresponding changes to the documentation
-   [x] I have run all new & existing test and pass locally with my changes
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request
