### PR TITLE
Fix comicinfo number field is overwrite when comicinfo file exist

### DIFF
--- a/internal/application/comicinfo.go
+++ b/internal/application/comicinfo.go
@@ -73,7 +73,7 @@ func (a *App) GetComicInfo(folder string) ComicInfoResponse {
 	}
 
 	// Fill by configuration
-	prov = cfgprov.New(a.cfg)
+	prov = cfgprov.New(a.cfg, absPath)
 	c, err = prov.Fill(c)
 
 	// Consider as acceptable error, log error only

--- a/internal/application/export.go
+++ b/internal/application/export.go
@@ -59,7 +59,7 @@ func (a *App) QuickExportKomga(inputDir string) string {
 	}
 
 	// Fill by configuration
-	prov = cfgprov.New(a.cfg)
+	prov = cfgprov.New(a.cfg, inputDir)
 	c, err = prov.Fill(c)
 
 	// Consider as acceptable error, log error only

--- a/internal/dataprovider/cfgprov/provider.go
+++ b/internal/dataprovider/cfgprov/provider.go
@@ -4,25 +4,29 @@ package cfgprov
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/dark-person/comicinfo-parser/internal/comicinfo"
 	"github.com/dark-person/comicinfo-parser/internal/config"
 	"github.com/dark-person/comicinfo-parser/internal/dataprovider"
+	"github.com/dark-person/comicinfo-parser/internal/files"
 )
 
 // Data provider that use default value stated in configuration.
 type ConfigProvider struct {
-	cfg *config.ProgramConfig
+	folderPath string
+	cfg        *config.ProgramConfig
 }
 
 var _ dataprovider.DataProvider = (*ConfigProvider)(nil)
 
 // Create a new data provider that use default value stated in configuration.
-func New(cfg *config.ProgramConfig) *ConfigProvider {
-	return &ConfigProvider{cfg: cfg}
+func New(cfg *config.ProgramConfig, folderPath string) *ConfigProvider {
+	return &ConfigProvider{cfg: cfg, folderPath: folderPath}
 }
 
 // Fill input comicinfo by configuration.
+// When comicinfo.xml is already exist, this provider will have no-ops.
 // There has two possiblity of fill method:
 //
 //  1. Fill success, return changed comicinfo and nil error
@@ -31,6 +35,11 @@ func (c *ConfigProvider) Fill(input *comicinfo.ComicInfo) (result *comicinfo.Com
 	// Ensure configuration is not empty
 	if c.cfg == nil {
 		return input, fmt.Errorf("configuration cannot be nil")
+	}
+
+	// Ignore fill when comicinfo file is exist
+	if files.IsFileExist(filepath.Join(c.folderPath, "ComicInfo.xml")) {
+		return input, nil
 	}
 
 	// Fill values


### PR DESCRIPTION
Close #171 

### Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have create/modify corresponding test for new changes
-   [x] I have made corresponding changes to the documentation
-   [x] I have run all new & existing test and pass locally with my changes
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request
