### PR TITLE
Support tag alias when autofill

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,16 @@ Currently, this feature support below fields:
 
 -   `Genre`
 -   `Publisher`
+-   `Translator`
 -   `Tags`
 
 More field will be added in near future.
+
+#### Tag Alias
+
+User can define a alias word for tag in database, for example `me-tag` can be alias for `my-tag`.
+
+Program when also use these alias when auto fill `Tags` field in comicinfo.
 
 ### Option to Export ComicInfo
 

--- a/internal/assets/embed.go
+++ b/internal/assets/embed.go
@@ -19,7 +19,7 @@ var schema embed.FS
 // Supported database schema version.
 //
 // Developer should change this value when any schema update performed.
-const supportedSchemaVersion = 2
+const supportedSchemaVersion = 3
 
 // Get embedded schema from filesystem.
 // Used for database schema migrations.

--- a/internal/assets/schema/3_alias_tag.down.sql
+++ b/internal/assets/schema/3_alias_tag.down.sql
@@ -1,0 +1,30 @@
+-- Delete view & alias tag table
+DROP VIEW "view_tags_alias";
+
+DROP TABLE "tags_alias";
+
+DROP TABLE "map_keyword_tags";
+
+-- Create a temp table of tags 
+CREATE TABLE "tmp_tags" (
+    "input" TEXT NOT NULL,
+    PRIMARY KEY("input")
+);
+
+-- Copy data from the old table to the new table.
+INSERT INTO
+    "tmp_tags" ("input")
+SELECT
+    ("input")
+FROM
+    "tags";
+
+-- Drop the old table.
+DROP TABLE "tags";
+
+-- Rename the new table to the original table's name.
+ALTER TABLE
+    "tmp_tags" RENAME TO "tags";
+
+-- SQLite version
+PRAGMA user_version = 2;

--- a/internal/assets/schema/3_alias_tag.up.sql
+++ b/internal/assets/schema/3_alias_tag.up.sql
@@ -1,0 +1,56 @@
+-- Rename current table to tmp
+ALTER TABLE
+    tags RENAME TO tmp_tags;
+
+-- Create new tags table
+CREATE TABLE "tags" (
+    "tag_id" INTEGER,
+    "input" TEXT UNIQUE,
+    PRIMARY KEY("tag_id" AUTOINCREMENT)
+);
+
+-- Create new table for tag alias
+CREATE TABLE "tags_alias" (
+    "alias" TEXT,
+    "tag_id" INTEGER,
+    PRIMARY KEY("alias")
+);
+
+-- Insert temp records back to new tag table
+INSERT INTO
+    "tags" ("input")
+SELECT
+    ("input")
+FROM
+    tmp_tags;
+
+-- Drop temp table
+DROP TABLE "tmp_tags";
+
+-- Create view for tag & tag alias
+CREATE VIEW "view_tags_alias" AS
+SELECT
+    tags_alias.alias,
+    tags.input as tag,
+    tags.tag_id as tag_id
+FROM
+    "tags_alias"
+    LEFT JOIN tags on tags_alias.tag_id = tags.tag_id;
+
+-- Create view for easier lookup
+CREATE VIEW map_keyword_tags as
+SELECT
+    tags_alias.alias as keyword,
+    tags.input as tag
+FROM
+    tags_alias
+    JOIN tags ON tags_alias.tag_id = tags.tag_id
+UNION
+SELECT
+    tags.input as keyword,
+    tags.input as tag
+FROM
+    tags;
+
+-- SQLite version
+PRAGMA user_version = 3;

--- a/internal/dataprovider/historyprov/provider.go
+++ b/internal/dataprovider/historyprov/provider.go
@@ -93,7 +93,7 @@ func (p *HistoryProvider) matchTags() ([]string, error) {
 	var err error
 
 	// Select tags that is matched
-	rows, err := p.db.Query("SELECT word from _tmp_autofill JOIN tags ON _tmp_autofill.word = tags.input")
+	rows, err := p.db.Query("SELECT tag from _tmp_autofill JOIN map_keyword_tags ON map_keyword_tags.keyword = _tmp_autofill.word")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dataprovider/historyprov/provider_test.go
+++ b/internal/dataprovider/historyprov/provider_test.go
@@ -47,6 +47,9 @@ func prepareDB() *lazydb.LazyDB {
 	// Tags
 	db.Exec(`INSERT INTO tags (input) VALUES ('abc'), ('def'), ('ghi')`)
 
+	// Alias tags
+	db.Exec(`INSERT INTO tags_alias (alias, tag_id) VALUES ('kcs', 1)`)
+
 	return db
 }
 
@@ -75,6 +78,10 @@ func TestAutoFillRun(t *testing.T) {
 		{
 			"(ghi) Another Bookname 2 (abc) [Test-Genre] [Test-Publisher] [Test-TranslatorXTest-Translator2] [invalid] [20240123]",
 			testResult{"Test-Genre", "Test-Publisher", "", "abc,ghi"},
+		},
+		{
+			"Another Bookname (kcs) [def]",
+			testResult{"", "", "", "abc,def"},
 		},
 	}
 


### PR DESCRIPTION
### Changes Made

- Change database schema for tag alias
- Allow auto fill to use tag alias

### Reason of Changes

Close #158.

### Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have create/modify corresponding test for new changes
-   [x] I have made corresponding changes to the documentation
-   [x] I have run all new & existing test and pass locally with my changes
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request
