### PR TITLE
Fix temp table not using `TEMPORARY` keyword

### DIFF
--- a/internal/dataprovider/historyprov/provider.go
+++ b/internal/dataprovider/historyprov/provider.go
@@ -36,7 +36,7 @@ func (p *HistoryProvider) parseToDB(bookname string) (err error) {
 	words := splitKeywords(bookname)
 
 	// Create temporary table
-	_, err = p.db.Exec("CREATE TABLE _tmp_autofill (word text)")
+	_, err = p.db.Exec("CREATE TEMPORARY TABLE _tmp_autofill (word text)")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Changes Made

Fix temporary table is not used when running autofill.

### Reason of Changes

This will cause problem if program accidently failed when auto fill (no drop table operation execute), which that table will still exist with data remain when running another autofill process.

This problem is difficult to reproduce in test case.

