### PR TITLE
[Breaking] Use triggers to replace tag alias and support more field

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ More field will be added in near future.
 
 Each time when generate comicinfo file, program will try to auto fill some values depends on folder name of selected folder.
 
-Folder name will be split to some keywords by space characters, and only fill value when keywords is same with inputted values in local database .
+Folder name will be split to some keywords by space characters, and only fill value when keywords is same with inputted values in local database.
 
 Currently, this feature support below fields:
 
@@ -61,13 +61,16 @@ Currently, this feature support below fields:
 -   `Translator`
 -   `Tags`
 
-More field will be added in near future.
+#### Triggers
 
-#### Tag Alias
+Advanced user can use `triggers` table in database to define keyword alias and its behavior.
 
-User can define a alias word for tag in database, for example `me-tag` can be alias for `my-tag`.
+For examplem, to auto fill `me-value` to `Genre` when detect `my-value` in bookname, user require to:
 
-Program when also use these alias when auto fill `Tags` field in comicinfo.
+1. Create `me-value` row in `word_store` table, with `category_id` for genre field
+2. Create `my-value` row in `triggers` table, with `word_id` in `word_store` table
+
+User should use software with GUI to perform CRUD for database.
 
 ### Option to Export ComicInfo
 

--- a/internal/assets/embed.go
+++ b/internal/assets/embed.go
@@ -19,7 +19,7 @@ var schema embed.FS
 // Supported database schema version.
 //
 // Developer should change this value when any schema update performed.
-const supportedSchemaVersion = 3
+const supportedSchemaVersion = 4
 
 // Get embedded schema from filesystem.
 // Used for database schema migrations.

--- a/internal/assets/schema/4_merge.up.sql
+++ b/internal/assets/schema/4_merge.up.sql
@@ -1,0 +1,76 @@
+CREATE TABLE "word_store" (
+    "word_id" INTEGER,
+    "word" TEXT,
+    "category_id" INTEGER,
+    PRIMARY KEY("word_id" AUTOINCREMENT),
+    UNIQUE("word", "category_id")
+);
+
+CREATE TABLE "triggers" (
+    "trigger_id" INTEGER,
+    "keyword" TEXT,
+    "word_id" INTEGER,
+    PRIMARY KEY("trigger_id" AUTOINCREMENT)
+);
+
+-- New category
+INSERT INTO
+    category (category_id, category_name)
+VALUES
+    (4, 'Tag');
+
+-- Migration from list_inputted & tags
+INSERT INTO
+    word_store (word, category_id)
+SELECT
+    input AS word,
+    category AS category_id
+FROM
+    list_inputted;
+
+INSERT INTO
+    word_store (word, category_id)
+SELECT
+    input AS word,
+    4 AS category_id
+FROM
+    tags;
+
+-- Migration from tag_alias
+INSERT INTO
+    triggers (keyword, word_id)
+SELECT
+    tags_alias.alias,
+    word_store.word_id
+FROM
+    tags_alias
+    LEFT JOIN tags ON tags.tag_id = tags_alias.tag_id
+    LEFT JOIN word_store ON tags.input = word_store.word
+    AND word_store.category_id = 4;
+
+-- New views on trigger and word
+CREATE VIEW view_triggers_words AS
+SELECT
+    trigger_id,
+    keyword,
+    word,
+    category_name,
+    word_store.category_id
+FROM
+    triggers
+    LEFT JOIN word_store ON word_store.word_id = triggers.word_id
+    LEFT JOIN category ON category.category_id = word_store.category_id;
+
+-- DROP old tables
+DROP TABLE list_inputted;
+
+DROP TABLE tags;
+
+DROP TABLE tags_alias;
+
+DROP VIEW view_tags_alias;
+
+DROP VIEW map_keyword_tags;
+
+-- SQLite version
+PRAGMA user_version = 4;

--- a/internal/dataprovider/historyprov/provider_test.go
+++ b/internal/dataprovider/historyprov/provider_test.go
@@ -47,8 +47,8 @@ func prepareDB() *lazydb.LazyDB {
 	// Tags
 	db.Exec(`INSERT INTO word_store (category_id, word) VALUES (4, 'abc'), (4, 'def'), (4, 'ghi')`)
 
-	// Alias tags
-	db.Exec(`INSERT INTO triggers (keyword, word_id) VALUES ('kcs', 4)`)
+	// Triggers
+	db.Exec(`INSERT INTO triggers (keyword, word_id) VALUES ('kcs', 4), ('aed', 1)`)
 
 	return db
 }
@@ -80,8 +80,8 @@ func TestAutoFillRun(t *testing.T) {
 			testResult{"Test-Genre", "Test-Publisher", "", "abc,ghi"},
 		},
 		{
-			"Another Bookname (kcs) [def]",
-			testResult{"", "", "", "abc,def"},
+			"Another Bookname (kcs) (aed) [def]",
+			testResult{"Test-Genre", "", "", "abc,def"},
 		},
 	}
 

--- a/internal/dataprovider/historyprov/provider_test.go
+++ b/internal/dataprovider/historyprov/provider_test.go
@@ -30,25 +30,25 @@ func prepareDB() *lazydb.LazyDB {
 	// Prepare some dummy data
 
 	// Genre
-	db.Exec("INSERT OR IGNORE INTO list_inputted (category, input) VALUES (?, ?)",
+	db.Exec("INSERT OR IGNORE INTO word_store (category_id, word) VALUES (?, ?)",
 		definitions.CategoryGenre,
 		"Test-Genre")
 
 	// Publisher
-	db.Exec("INSERT OR IGNORE INTO list_inputted (category, input) VALUES (?, ?)",
+	db.Exec("INSERT OR IGNORE INTO word_store (category_id, word) VALUES (?, ?)",
 		definitions.CategoryPublisher,
 		"Test-Publisher")
 
 	// Tranlator
-	db.Exec("INSERT OR IGNORE INTO list_inputted (category, input) VALUES (?, ?)",
+	db.Exec("INSERT OR IGNORE INTO word_store (category_id, word) VALUES (?, ?)",
 		definitions.CategoryTranslator,
 		"Test-Translator")
 
 	// Tags
-	db.Exec(`INSERT INTO tags (input) VALUES ('abc'), ('def'), ('ghi')`)
+	db.Exec(`INSERT INTO word_store (category_id, word) VALUES (4, 'abc'), (4, 'def'), (4, 'ghi')`)
 
 	// Alias tags
-	db.Exec(`INSERT INTO tags_alias (alias, tag_id) VALUES ('kcs', 1)`)
+	db.Exec(`INSERT INTO triggers (keyword, word_id) VALUES ('kcs', 4)`)
 
 	return db
 }

--- a/internal/definitions/category.go
+++ b/internal/definitions/category.go
@@ -8,9 +8,10 @@ const (
 	CategoryGenre      CategoryType = iota + 1 // Database value for Genre.
 	CategoryPublisher                          // Database value for Publisher.
 	CategoryTranslator                         // Database value for Translator.
+	CategoryTag                                // Database value for Tag.
 )
 
 // Return a slices of category type.
 func Categories() []CategoryType {
-	return []CategoryType{CategoryGenre, CategoryPublisher, CategoryTranslator}
+	return []CategoryType{CategoryGenre, CategoryPublisher, CategoryTranslator, CategoryTag}
 }

--- a/internal/store/history_core.go
+++ b/internal/store/history_core.go
@@ -23,7 +23,7 @@ func insertValue(db *lazydb.LazyDB, category definitions.CategoryType, value ...
 
 		prepared = append(prepared,
 			lazydb.Param(
-				"INSERT OR IGNORE INTO list_inputted (category, input) VALUES (?, ?)",
+				"INSERT OR IGNORE INTO word_store (category_id, word) VALUES (?, ?)",
 				category, item,
 			))
 	}
@@ -41,7 +41,7 @@ func getHistory(db *lazydb.LazyDB, category definitions.CategoryType) ([]string,
 	}
 
 	// Execute query
-	rows, err := db.Query("SELECT input FROM list_inputted WHERE category = ?", category)
+	rows, err := db.Query("SELECT word FROM word_store WHERE category_id = ?", category)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/history_core_test.go
+++ b/internal/store/history_core_test.go
@@ -13,7 +13,7 @@ import (
 // Function to check how many rows in db has given category & value.
 func checkHistoryRowCount(a *lazydb.LazyDB, category definitions.CategoryType, value string) (int, error) {
 	// Get Inserted rows
-	rows, err := a.Query("SELECT COUNT(*) FROM list_inputted WHERE category=? AND input=?", category, value)
+	rows, err := a.Query("SELECT COUNT(*) FROM word_store WHERE category_id=? AND word=?", category, value)
 	if err != nil {
 		return -1, err
 	}
@@ -47,7 +47,7 @@ func createTestHistoryDB(path string, withData bool) (*lazydb.LazyDB, error) {
 	}
 
 	// Insert data rows
-	sql := `INSERT INTO list_inputted (category, input) VALUES (45,'123'), (56, '123'), (56, '456')`
+	sql := `INSERT INTO word_store (category_id, word) VALUES (45,'123'), (56, '123'), (56, '456')`
 	_, err = a.Exec(sql)
 	if err != nil {
 		return nil, err

--- a/internal/store/tag.go
+++ b/internal/store/tag.go
@@ -21,7 +21,7 @@ func AddTag(db *lazydb.LazyDB, tags ...string) error {
 		}
 
 		prepared = append(prepared, lazydb.Param(
-			"INSERT OR IGNORE INTO tags (input) VALUES (?)",
+			"INSERT OR IGNORE INTO word_store (word, category_id) VALUES (?, 4)",
 			item,
 		))
 	}
@@ -39,7 +39,7 @@ func GetAllTags(db *lazydb.LazyDB) ([]string, error) {
 	}
 
 	// Prepare SQL & its args
-	query := "SELECT input FROM tags ORDER BY input"
+	query := "SELECT word FROM word_store WHERE category_id = 4 ORDER BY word"
 
 	// Execute query
 	rows, err := db.Query(query)

--- a/internal/store/tag_test.go
+++ b/internal/store/tag_test.go
@@ -56,7 +56,7 @@ func createTestTagDB(path string) (*lazydb.LazyDB, error) {
 	}
 
 	// Insert data rows
-	_, err = db.Exec(`INSERT INTO tags (input) VALUES ('abc'), ('def'), ('ghi')`)
+	_, err = db.Exec(`INSERT INTO word_store (word, category_id) VALUES ('abc', 4), ('def', 4), ('ghi', 4)`)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func createTestTagDB(path string) (*lazydb.LazyDB, error) {
 // Function to check how many rows in db has given tag.
 func checkTagRowCount(a *lazydb.LazyDB, value string) (int, error) {
 	// Execute query
-	rows, err := a.Query("SELECT COUNT(*) FROM tags WHERE input=?", value)
+	rows, err := a.Query("SELECT COUNT(*) FROM word_store WHERE word=? AND category_id=4", value)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
### Changes Made

- Update database schema to v4
   - Merge table `list_inputted` and `tags`
   - Use `triggers` to replace functionality of `tag_alias`
- Rewrite all SQL in `historyprov` package due to database change

### Reason of Changes

Use `triggers` can ensure more field supported when autofill, and allow single keyword to fill multiple field in comicinfo.

### Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have create/modify corresponding test for new changes
-   [x] I have made corresponding changes to the documentation
-   [x] I have run all new & existing test and pass locally with my changes
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request
