### PR TITLE
Fix leading and trailing white space affect word result in `historyprov`

### DIFF
--- a/internal/store/history_core.go
+++ b/internal/store/history_core.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"strings"
+
 	"github.com/dark-person/comicinfo-parser/internal/definitions"
 	"github.com/dark-person/lazydb"
 )
@@ -24,7 +26,7 @@ func insertValue(db *lazydb.LazyDB, category definitions.CategoryType, value ...
 		prepared = append(prepared,
 			lazydb.Param(
 				"INSERT OR IGNORE INTO word_store (category_id, word) VALUES (?, ?)",
-				category, item,
+				category, strings.TrimSpace(item),
 			))
 	}
 

--- a/internal/store/history_core_test.go
+++ b/internal/store/history_core_test.go
@@ -93,6 +93,9 @@ func TestInsertValue(t *testing.T) {
 		// Empty string value
 		{"test5.db", 45, []string{"123", ""}, false, []int{1, 0}},
 
+		// Duplicate test with space
+		{"test6.db", 45, []string{"789", "789 "}, false, []int{1, 0}},
+
 		// Nil database
 		{"", 45, []string{"123"}, true, []int{1}},
 	}

--- a/internal/store/tag.go
+++ b/internal/store/tag.go
@@ -1,6 +1,10 @@
 package store
 
-import "github.com/dark-person/lazydb"
+import (
+	"strings"
+
+	"github.com/dark-person/lazydb"
+)
 
 // Add tags to given LazyDB. This function support multiple tags insert at once.
 //
@@ -22,7 +26,7 @@ func AddTag(db *lazydb.LazyDB, tags ...string) error {
 
 		prepared = append(prepared, lazydb.Param(
 			"INSERT OR IGNORE INTO word_store (word, category_id) VALUES (?, 4)",
-			item,
+			strings.TrimSpace(item),
 		))
 	}
 

--- a/internal/store/tag_test.go
+++ b/internal/store/tag_test.go
@@ -106,6 +106,9 @@ func TestAddTag(t *testing.T) {
 		{"test3.db", []string{""}, false, []int{0}},
 		{"test4.db", []string{"abc", ""}, false, []int{1, 0}},
 
+		// Duplicate with space around
+		{"test5.db", []string{"abc", "abc "}, false, []int{1, 0}},
+
 		// Nil Database
 		{"", []string{"abc"}, true, []int{1}},
 	}


### PR DESCRIPTION
### Bug Cause & Solution

Fix database may insert value with leading and trailing space, which make `historyprov` cannot found matched words.

### Checklist:

#### Code Checklist:

-   [ ] I have run the new code and ensure the change is work expected
-   [ ] I have run the new code for given condition and ensure the bugs is not appear again
-   [ ] I have write/modify comments to important function & hard-to-understand code
-   [ ] I have checked my code has no misspellings & no warnings
-   [ ] I have checked that only essential code remains in this pull request

#### Documentation Checklist:

-   [ ] I have modify file description to README.md of the package (if any)

#### Testing Checklist:

-   [ ] I have create new test case for reproduce this bug
-   [ ] I have run all new test case and pass locally with my changes
-   [ ] I have run all existing test and pass locally with my changes
