### PR TITLE
Support autofill value for writer in comicinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ User can use these values when they generate another comicinfo, with easy-to-use
 Currently, this feature support below fields:
 
 -   `Genre`
+-   `Writer`
 -   `Publisher`
+-   `Translator`
 -   `Tags`
 
 More field will be added in near future.
@@ -57,6 +59,7 @@ Folder name will be split to some keywords by space characters, and only fill va
 Currently, this feature support below fields:
 
 -   `Genre`
+-   `Writer`
 -   `Publisher`
 -   `Translator`
 -   `Tags`

--- a/internal/application/export.go
+++ b/internal/application/export.go
@@ -111,6 +111,16 @@ func (a *App) saveToHistory(c *comicinfo.ComicInfo) error {
 		})
 	}
 
+	// ----------- Writer ----------------
+	// Split the publisher into slice of string by comma
+	s = strings.Split(c.Writer, ",")
+	for _, item := range s {
+		values = append(values, store.HistoryVal{
+			Category: definitions.CategoryWriter,
+			Value:    item,
+		})
+	}
+
 	// ----------- Publisher ----------------
 	// Split the publisher into slice of string by comma
 	s = strings.Split(c.Publisher, ",")

--- a/internal/assets/embed.go
+++ b/internal/assets/embed.go
@@ -19,7 +19,7 @@ var schema embed.FS
 // Supported database schema version.
 //
 // Developer should change this value when any schema update performed.
-const supportedSchemaVersion = 4
+const supportedSchemaVersion = 5
 
 // Get embedded schema from filesystem.
 // Used for database schema migrations.

--- a/internal/assets/schema/5_writer.up.sql
+++ b/internal/assets/schema/5_writer.up.sql
@@ -1,0 +1,8 @@
+-- New category
+INSERT INTO
+    category (category_id, category_name)
+VALUES
+    (5, 'Writer');
+
+-- SQLite version
+PRAGMA user_version = 5;

--- a/internal/comicinfo/extend.go
+++ b/internal/comicinfo/extend.go
@@ -12,6 +12,12 @@ func (c *ComicInfo) AddGenre(genre ...string) {
 	c.Genre = AddValue(c.Genre, genre...)
 }
 
+// Add writer to the comic info container.
+// This function will handle the comma separation automatically.
+func (c *ComicInfo) AddWriter(writer ...string) {
+	c.Writer = AddValue(c.Writer, writer...)
+}
+
 // Add publishers to the comic info container.
 // This function will handle the comma separation automatically.
 func (c *ComicInfo) AddPublisher(publisher ...string) {

--- a/internal/dataprovider/historyprov/provider.go
+++ b/internal/dataprovider/historyprov/provider.go
@@ -186,6 +186,9 @@ func (p *HistoryProvider) Fill(c *comicinfo.ComicInfo) (out *comicinfo.ComicInfo
 	c.AddGenre(inputted[definitions.CategoryGenre]...)
 	c.AddGenre(triggers[definitions.CategoryGenre]...)
 
+	c.AddWriter(inputted[definitions.CategoryWriter]...)
+	c.AddWriter(triggers[definitions.CategoryWriter]...)
+
 	c.AddPublisher(inputted[definitions.CategoryPublisher]...)
 	c.AddPublisher(triggers[definitions.CategoryPublisher]...)
 

--- a/internal/dataprovider/historyprov/provider_test.go
+++ b/internal/dataprovider/historyprov/provider_test.go
@@ -47,6 +47,9 @@ func prepareDB() *lazydb.LazyDB {
 	// Tags
 	db.Exec(`INSERT INTO word_store (category_id, word) VALUES (4, 'abc'), (4, 'def'), (4, 'ghi')`)
 
+	// Writers
+	db.Exec(`INSERT INTO word_store (category_id, word) VALUES (?, ?)`, definitions.CategoryWriter, "Test-Writer")
+
 	// Triggers
 	db.Exec(`INSERT INTO triggers (keyword, word_id) VALUES ('kcs', 4), ('aed', 1)`)
 
@@ -59,6 +62,7 @@ func TestAutoFillRun(t *testing.T) {
 
 	type testResult struct {
 		genre      string
+		writer     string
 		publisher  string
 		translator string
 		tags       string
@@ -73,15 +77,15 @@ func TestAutoFillRun(t *testing.T) {
 	// Start test
 	tests := []testCase{
 		{
-			"Some Bookname (abc) [Test-Translator] [Test-Translator2] [def]",
-			testResult{"", "", "Test-Translator", "abc,def"}},
+			"[Test-Writer] Some Bookname (abc) [Test-Translator] [Test-Translator2] [def]",
+			testResult{"", "Test-Writer", "", "Test-Translator", "abc,def"}},
 		{
 			"(ghi) Another Bookname 2 (abc) [Test-Genre] [Test-Publisher] [Test-TranslatorXTest-Translator2] [invalid] [20240123]",
-			testResult{"Test-Genre", "Test-Publisher", "", "abc,ghi"},
+			testResult{"Test-Genre", "", "Test-Publisher", "", "abc,ghi"},
 		},
 		{
 			"Another Bookname (kcs) (aed) [def]",
-			testResult{"Test-Genre", "", "", "abc,def"},
+			testResult{"Test-Genre", "", "", "", "abc,def"},
 		},
 	}
 
@@ -103,6 +107,7 @@ func TestAutoFillRun(t *testing.T) {
 
 		// Compare values
 		assert.EqualValuesf(t, tt.want.genre, info.Genre, "unmatched genre value in case %d", idx)
+		assert.EqualValuesf(t, tt.want.writer, info.Writer, "unmatched writer value in case %d", idx)
 		assert.EqualValuesf(t, tt.want.publisher, info.Publisher, "unmatched publisher value in case %d", idx)
 		assert.EqualValuesf(t, tt.want.translator, info.Translator, "unmatched translator value in case %d", idx)
 		assert.EqualValuesf(t, tt.want.tags, info.Tags, "unmatched tag value in case %d", idx)

--- a/internal/definitions/category.go
+++ b/internal/definitions/category.go
@@ -9,9 +9,10 @@ const (
 	CategoryPublisher                          // Database value for Publisher.
 	CategoryTranslator                         // Database value for Translator.
 	CategoryTag                                // Database value for Tag.
+	CategoryWriter                             // Database value for Writer
 )
 
 // Return a slices of category type.
 func Categories() []CategoryType {
-	return []CategoryType{CategoryGenre, CategoryPublisher, CategoryTranslator, CategoryTag}
+	return []CategoryType{CategoryGenre, CategoryPublisher, CategoryTranslator, CategoryTag, CategoryWriter}
 }


### PR DESCRIPTION
### Changes (New Feature)

Support autofill writer in comicinfo, with `historyprov`.

This also update database schema for category.

### Checklist:

#### Code Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request

#### Documentation Checklist:

-   [x] I have add new feature description to README.md of this repository
-   [x] I have add/modify file description to README.md of the package (tick if not applicable)

#### Testing Checklist:

-   [x] I have create new test case / test for new feature
-   [x] I have run all new & existing test and pass locally with my changes
